### PR TITLE
Converting resource id in Grafana to hyperlink

### DIFF
--- a/SchedulePipelineFunctionApp/TimerStartPipelineFunction.cs
+++ b/SchedulePipelineFunctionApp/TimerStartPipelineFunction.cs
@@ -73,12 +73,12 @@ namespace Observability.SchedulePipelineFunctionApp
                 {
                     subscriptionNameResponse.Read();
                     subscriptionName = subscriptionNameResponse.GetString(1);
-                    tenantDomain = resourceClient.GetTenantDomainAsync(config).ToString();
+                    tenantDomain = resourceClient.GetTenantDomainAsync(config).Result;
                 }
                 else
                 {
                     subscriptionName = resourceClient.GetSubscriptionName(subscriptionId.ToString()); //TODO: make asynchronous
-                    tenantDomain = resourceClient.GetTenantDomainAsync(config).ToString();
+                    tenantDomain = resourceClient.GetTenantDomainAsync(config).Result;
                     await adx.IngestSubscriptionNameAsync(subscriptionId.ToString(), subscriptionName, tenantDomain);
                 }
 

--- a/SchedulePipelineFunctionApp/TimerStartPipelineFunction.cs
+++ b/SchedulePipelineFunctionApp/TimerStartPipelineFunction.cs
@@ -68,15 +68,18 @@ namespace Observability.SchedulePipelineFunctionApp
                 var subscriptionNameResponse = kustoClient.ExecuteQuery(subscriptionNameQuery);
 
                 var subscriptionName = "";
+                var tenantDomain = "";
                 if (subscriptionNameResponse.Read())
                 {
                     subscriptionNameResponse.Read();
                     subscriptionName = subscriptionNameResponse.GetString(1);
+                    tenantDomain = resourceClient.GetTenantDomainAsync(config).ToString();
                 }
                 else
                 {
                     subscriptionName = resourceClient.GetSubscriptionName(subscriptionId.ToString()); //TODO: make asynchronous
-                    await adx.IngestSubscriptionNameAsync(subscriptionId.ToString(), subscriptionName);
+                    tenantDomain = resourceClient.GetTenantDomainAsync(config).ToString();
+                    await adx.IngestSubscriptionNameAsync(subscriptionId.ToString(), subscriptionName, tenantDomain);
                 }
 
                 log.LogInformation($"This is the Subscription name: {subscriptionName}");

--- a/Utils/AdxClientHelper.cs
+++ b/Utils/AdxClientHelper.cs
@@ -44,12 +44,12 @@ namespace Observability.Utils
             return kcsb;
         }
 
-        public async Task IngestSubscriptionNameAsync(string subscriptionId, string subscriptionName)
+        public async Task IngestSubscriptionNameAsync(string subscriptionId, string subscriptionName, string tenantDomain)
         {
             var kcsb = GetClient();
             var kustoClient = KustoClientFactory.CreateCslAdminProvider(kcsb); //TODO: Why created in every method, could be in class constructor?
 
-            var ingestQuery = $".ingest inline into table Subscription_Names <| {subscriptionId}, {subscriptionName}";
+            var ingestQuery = $".ingest inline into table Subscription_Names <| {subscriptionId}, {subscriptionName}, {tenantDomain}";
             await kustoClient.ExecuteControlCommandAsync(databaseName, ingestQuery);
         }
 

--- a/Utils/ResourceGraphHelper.cs
+++ b/Utils/ResourceGraphHelper.cs
@@ -66,24 +66,54 @@ namespace Observability.Utils
             using var response = await _httpClient.SendAsync(httpRequest);
 
             var result = await response.Content.ReadAsStringAsync();
+            /*
+                        JToken responseJson = JToken.Parse(result);
+                        JArray value = (JArray)responseJson["value"];
 
-            JToken responseJson = JToken.Parse(result);
-            JArray value = (JArray)responseJson["value"];
 
+                        *//*foreach (JToken tenantid in value)
+                        {
+                            string id = tenantid["tenantId"].ToString();
+                            if (id == tenant.ToString())
+                            {
+                                string defaultDomain = tenantid["defaultDomain"].ToString();
+                                return defaultDomain;
+                            }
+                        }
 
-            /*foreach (JToken tenantid in value)
+                        return "Default Domain Name not found for Tenant ID";*/
+
+            string defaultDomain = "Null Value";
+            string nullField = "";
+            try
             {
-                string id = tenantid["tenantId"].ToString();
-                if (id == tenant.ToString())
+                JToken responseJson = JToken.Parse(result);
+                JArray value = (JArray)responseJson["value"];
+                if (value != null && value.Count > 0 && value[0]["defaultDomain"] != null)
                 {
-                    string defaultDomain = tenantid["defaultDomain"].ToString();
-                    return defaultDomain;
+                    defaultDomain = value[0]["defaultDomain"].ToString();
+                }
+                else
+                {
+                    if (value == null)
+                    {
+                        nullField = "value";
+                    }
+                    else if (value.Count == 0)
+                    {
+                        nullField = "value[0]";
+                    }
+                    else if (value[0]["defaultDomain"] == null)
+                    {
+                        nullField = "value[0][\"defaultDomain\"]";
+                    }
+                    return $"The field {nullField} was null.";
                 }
             }
-
-            return "Default Domain Name not found for Tenant ID";*/
-
-            string defaultDomain = value[0]["defaultDomain"].ToString();
+            catch (Exception e)
+            {
+                return e.Message;
+            }
             return defaultDomain;
 
         }

--- a/Utils/ResourceGraphHelper.cs
+++ b/Utils/ResourceGraphHelper.cs
@@ -11,6 +11,7 @@ using Microsoft.Identity.Client;
 using Azure.Core;
 using System.Net.Http.Headers;
 using Newtonsoft.Json.Linq;
+using Microsoft.Azure.Management.ResourceManager.Fluent.Models;
 
 namespace Observability.Utils
 {
@@ -49,7 +50,7 @@ namespace Observability.Utils
         
         public async Task<String> GetTenantDomainAsync(IConfiguration config)
         {
-            var tenant = client.GetTenants().FirstOrDefault().Id;
+            //var tenant = client.GetTenants().FirstOrDefault().Id;
             string managementUrl = "https://management.azure.com/tenants?api-version=2022-12-01";
 
             using HttpRequestMessage httpRequest = new HttpRequestMessage(HttpMethod.Get, managementUrl);
@@ -67,10 +68,10 @@ namespace Observability.Utils
             var result = await response.Content.ReadAsStringAsync();
 
             JToken responseJson = JToken.Parse(result);
-            JArray tenants = (JArray)responseJson["value"];
+            JArray value = (JArray)responseJson["value"];
 
 
-            foreach (JToken tenantid in tenants)
+            /*foreach (JToken tenantid in value)
             {
                 string id = tenantid["tenantId"].ToString();
                 if (id == tenant.ToString())
@@ -80,7 +81,10 @@ namespace Observability.Utils
                 }
             }
 
-            return "Default Domain Name not found for Tenant ID";
+            return "Default Domain Name not found for Tenant ID";*/
+
+            string defaultDomain = value[0]["defaultDomain"].ToString();
+            return defaultDomain;
 
         }
 

--- a/Utils/ResourceGraphHelper.cs
+++ b/Utils/ResourceGraphHelper.cs
@@ -49,7 +49,7 @@ namespace Observability.Utils
         
         public async Task<String> GetTenantDomainAsync(IConfiguration config)
         {
-            var tenant = client.GetTenants().FirstOrDefault();
+            var tenant = client.GetTenants().FirstOrDefault().Id;
             string managementUrl = "https://management.azure.com/tenants?api-version=2022-12-01";
 
             using HttpRequestMessage httpRequest = new HttpRequestMessage(HttpMethod.Get, managementUrl);

--- a/Utils/scripts/dashboard_templates/AksServerNode-1679088882867.json
+++ b/Utils/scripts/dashboard_templates/AksServerNode-1679088882867.json
@@ -1,233 +1,273 @@
 {
-  "annotations": {
-    "list": [
-      {
-        "builtIn": 1,
-        "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
-        },
-        "enable": true,
-        "hide": true,
-        "iconColor": "rgba(0, 211, 255, 1)",
-        "name": "Annotations & Alerts",
-        "target": {
-          "limit": 100,
-          "matchAny": false,
-          "tags": [],
-          "type": "dashboard"
-        },
-        "type": "dashboard"
-      }
-    ]
-  },
-  "editable": true,
-  "fiscalYearStartMonth": 0,
-  "graphTooltip": 0,
-  "id": 32,
-  "links": [],
-  "liveNow": false,
-  "panels": [
-    {
-      "datasource": {
-        "type": "grafana-azure-data-explorer-datasource",
-        "uid": "uRhkgPj4k"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "align": "auto",
-            "displayMode": "color-text",
-            "filterable": true,
-            "inspect": true
-          },
-          "decimals": 3,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-red",
-                "value": null
-              },
-              {
-                "color": "dark-green",
-                "value": 100
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 2,
-      "options": {
-        "footer": {
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": true
-      },
-      "pluginVersion": "9.3.8",
-      "targets": [
-        {
-          "database": "func04-metricsdb",
-          "datasource": {
-            "type": "grafana-azure-data-explorer-datasource",
-            "uid": "uRhkgPj4k"
-          },
-          "expression": {
-            "from": {
-              "property": {
-                "name": "Vm_Availability",
-                "type": "string"
-              },
-              "type": "property"
-            },
-            "groupBy": {
-              "expressions": [],
-              "type": "and"
-            },
-            "reduce": {
-              "expressions": [],
-              "type": "and"
-            },
-            "where": {
-              "expressions": [],
-              "type": "and"
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": {
+                    "type": "grafana",
+                    "uid": "-- Grafana --"
+                },
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "target": {
+                    "limit": 100,
+                    "matchAny": false,
+                    "tags": [],
+                    "type": "dashboard"
+                },
+                "type": "dashboard"
             }
-          },
-          "pluginVersion": "4.2.0",
-          "query": "Subscriptions\n|join Aksservernode_Availability on subscriptionId\n| project component, createdAt, ['date'], id, location, name, nodeNotReady,\n nodeReady, nodeUnknown,solution, subscriptionId,tenancy, availability = ((nodeReady )/(nodeNotReady +nodeReady))*100\n| where $__timeFilter(['date'])\n and location in ($Region) and subscriptionId in ($Subscriptions)\n and solution in ($Solution) and availability < 100\n| project ['date'] , subscriptionId, id, location, name, availability\n| order by availability asc \n| order by ['date'] asc",
-          "querySource": "raw",
-          "rawMode": true,
-          "refId": "A",
-          "resultFormat": "table"
+        ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 31,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+        {
+            "datasource": {
+                "type": "grafana-azure-data-explorer-datasource",
+                "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "align": "auto",
+                        "cellOptions": {
+                            "type": "color-text"
+                        },
+                        "filterable": true,
+                        "inspect": true
+                    },
+                    "decimals": 3,
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "dark-red",
+                                "value": null
+                            },
+                            {
+                                "color": "dark-green",
+                                "value": 100
+                            }
+                        ]
+                    }
+                },
+                "overrides": [
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "id"
+                        },
+                        "properties": [
+                            {
+                                "id": "links",
+                                "value": [
+                                    {
+                                        "targetBlank": true,
+                                        "title": "",
+                                        "url": "https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource${__value.raw}/overview"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            "gridPos": {
+                "h": 10,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 2,
+            "options": {
+                "cellHeight": "sm",
+                "footer": {
+                    "countRows": false,
+                    "fields": "",
+                    "reducer": [
+                        "sum"
+                    ],
+                    "show": false
+                },
+                "showHeader": true
+            },
+            "pluginVersion": "9.5.6",
+            "targets": [
+                {
+                    "database": "sk001-metricsdb",
+                    "datasource": {
+                        "type": "grafana-azure-data-explorer-datasource",
+                        "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                    },
+                    "expression": {
+                        "from": {
+                            "property": {
+                                "name": "Vm_Availability",
+                                "type": "string"
+                            },
+                            "type": "property"
+                        },
+                        "groupBy": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "reduce": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "where": {
+                            "expressions": [],
+                            "type": "and"
+                        }
+                    },
+                    "pluginVersion": "4.5.0",
+                    "query": "Subscriptions\n|join Aksservernode_Availability on subscriptionId\n| project component, createdAt, ['date'], id, location, name, nodeNotReady,\n nodeReady, nodeUnknown,solution, subscriptionId,tenancy, availability = ((nodeReady )/(nodeNotReady +nodeReady))*100\n| where $__timeFilter(['date'])\n and location in ($Region) and subscriptionId in ($Subscriptions)\n and solution in ($Solution) and availability < 100\n| project ['date'] , subscriptionId, id, location, name, availability\n| order by availability asc \n| order by ['date'] asc",
+                    "querySource": "raw",
+                    "queryType": "KQL",
+                    "rawMode": true,
+                    "refId": "A",
+                    "resultFormat": "table"
+                }
+            ],
+            "title": "# of AksServerNode with Availability < 100",
+            "type": "table"
         }
-      ],
-      "title": "# of AksServerNode with Availability < 100",
-      "type": "table"
-    }
-  ],
-  "refresh": false,
-  "schemaVersion": 37,
-  "style": "dark",
-  "tags": [],
-  "templating": {
-    "list": [
-      {
-        "current": {
-          "selected": false,
-          "text": "2023-01-12 00:00:00",
-          "value": "2023-01-12 00:00:00"
-        },
-        "hide": 2,
-        "name": "selecteddate",
-        "options": [
-          {
-            "selected": true,
-            "text": "2023-03-16 20:42:00",
-            "value": "2023-03-16 20:42:00"
-          }
-        ],
-        "query": "2023-03-16 20:42:00",
-        "skipUrlSync": false,
-        "type": "textbox",
-        "datasource": null
-      },
-      {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
-        "datasource": {
-          "type": "grafana-azure-data-explorer-datasource",
-          "uid": "uRhkgPj4k"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": true,
-        "name": "Subscriptions",
-        "options": [],
-        "query": "",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
-        "datasource": {
-          "type": "grafana-azure-data-explorer-datasource",
-          "uid": "uRhkgPj4k"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": true,
-        "name": "Region",
-        "options": [],
-        "query": "",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
-        "datasource": {
-          "type": "grafana-azure-data-explorer-datasource",
-          "uid": "uRhkgPj4k"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": true,
-        "name": "Solution",
-        "options": [],
-        "query": "",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      }
-    ]
-  },
-  "time": {
-    "from": "now-6h",
-    "to": "now"
-  },
-  "timepicker": {},
-  "timezone": "utc",
-  "title": "AksServerNode",
-  "uid": "OD9S0za4z",
-  "version": 28,
-  "weekStart": ""
+    ],
+    "refresh": "",
+    "schemaVersion": 38,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+        "list": [
+            {
+                "current": {
+                    "selected": false,
+                    "text": "2023-09-03 13:15:00",
+                    "value": "2023-09-03 13:15:00"
+                },
+                "hide": 2,
+                "name": "selecteddate",
+                "options": [
+                    {
+                        "selected": false,
+                        "text": "2023-03-16 20:42:00",
+                        "value": "2023-03-16 20:42:00"
+                    }
+                ],
+                "query": "2023-09-03 13:15:00",
+                "skipUrlSync": false,
+                "type": "textbox"
+            },
+            {
+                "current": {
+                    "selected": false,
+                    "text": [
+                        "d6a99beb-93da-4c87-8e7a-2ad995aa1c94"
+                    ],
+                    "value": [
+                        "d6a99beb-93da-4c87-8e7a-2ad995aa1c94"
+                    ]
+                },
+                "datasource": {
+                    "type": "grafana-azure-data-explorer-datasource",
+                    "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                },
+                "definition": "",
+                "hide": 2,
+                "includeAll": false,
+                "multi": true,
+                "name": "Subscriptions",
+                "options": [],
+                "query": "",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
+            },
+            {
+                "current": {
+                    "selected": false,
+                    "text": [
+                        "eastus",
+                        "westus",
+                        "westus2",
+                        "eastus2",
+                        "northcentralus"
+                    ],
+                    "value": [
+                        "eastus",
+                        "westus",
+                        "westus2",
+                        "eastus2",
+                        "northcentralus"
+                    ]
+                },
+                "datasource": {
+                    "type": "grafana-azure-data-explorer-datasource",
+                    "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                },
+                "definition": "",
+                "hide": 2,
+                "includeAll": false,
+                "multi": true,
+                "name": "Region",
+                "options": [],
+                "query": "",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
+            },
+            {
+                "current": {
+                    "selected": false,
+                    "text": [
+                        "Solution 1"
+                    ],
+                    "value": [
+                        "Solution 1"
+                    ]
+                },
+                "datasource": {
+                    "type": "grafana-azure-data-explorer-datasource",
+                    "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                },
+                "definition": "",
+                "hide": 2,
+                "includeAll": false,
+                "multi": true,
+                "name": "Solution",
+                "options": [],
+                "query": "",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-6h",
+        "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "utc",
+    "title": "AksServerNode",
+    "uid": "OD9S0za4z",
+    "version": 4,
+    "weekStart": ""
 }

--- a/Utils/scripts/dashboard_templates/AzureResourceObservability-1687853750785.json
+++ b/Utils/scripts/dashboard_templates/AzureResourceObservability-1687853750785.json
@@ -1,2466 +1,2449 @@
 {
-  "annotations": {
-    "list": [
-      {
-        "builtIn": 1,
-        "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
-        },
-        "enable": true,
-        "hide": true,
-        "iconColor": "rgba(0, 211, 255, 1)",
-        "name": "Annotations & Alerts",
-        "target": {
-          "limit": 100,
-          "matchAny": false,
-          "tags": [],
-          "type": "dashboard"
-        },
-        "type": "dashboard"
-      }
-    ]
-  },
-  "editable": true,
-  "fiscalYearStartMonth": 0,
-  "graphTooltip": 0,
-  "id": 26,
-  "links": [],
-  "liveNow": false,
-  "panels": [
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 2,
-      "panels": [],
-      "title": "Resource inventory in selected period",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "grafana-azure-data-explorer-datasource",
-        "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 20,
-        "x": 0,
-        "y": 1
-      },
-      "id": 21,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "Avg availability of services shown here includes data from all events (platform caused and user errors)",
-        "mode": "markdown"
-      },
-      "pluginVersion": "9.5.6",
-      "targets": [
-        {
-          "database": "hotfix01-metricsdb",
-          "datasource": {
-            "type": "grafana-azure-data-explorer-datasource",
-            "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-          },
-          "expression": {
-            "from": {
-              "property": {
-                "name": "vm_availability",
-                "type": "string"
-              },
-              "type": "property"
-            },
-            "groupBy": {
-              "expressions": [],
-              "type": "and"
-            },
-            "reduce": {
-              "expressions": [],
-              "type": "and"
-            },
-            "where": {
-              "expressions": [],
-              "type": "and"
-            }
-          },
-          "pluginVersion": "4.2.0",
-          "query": "loadbalancer_availability\n| where $__timeFilter(['date'])// and region  in ($Region)\n| summarize dcount(id)",
-          "querySource": "raw",
-          "rawMode": true,
-          "refId": "A",
-          "resultFormat": "table"
-        }
-      ],
-      "title": "Note",
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "grafana-azure-data-explorer-datasource",
-        "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 0,
-        "y": 3
-      },
-      "id": 17,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.5.6",
-      "targets": [
-        {
-          "database": "hotfix01-metricsdb",
-          "datasource": {
-            "type": "grafana-azure-data-explorer-datasource",
-            "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-          },
-          "expression": {
-            "from": {
-              "property": {
-                "name": "Storage_Availability",
-                "type": "string"
-              },
-              "type": "property"
-            },
-            "groupBy": {
-              "expressions": [],
-              "type": "and"
-            },
-            "reduce": {
-              "expressions": [],
-              "type": "and"
-            },
-            "where": {
-              "expressions": [],
-              "type": "and"
-            }
-          },
-          "pluginVersion": "4.2.0",
-          "query": "Storage_Availability\n| where $__timeFilter(['date']) and location in ($Region) and subscriptionId in ($Subscriptions)\n| summarize dcount(id)",
-          "querySource": "raw",
-          "rawMode": true,
-          "refId": "A",
-          "resultFormat": "table"
-        }
-      ],
-      "title": "Total # of Storage",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "grafana-azure-data-explorer-datasource",
-        "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 4,
-        "y": 3
-      },
-      "id": 30,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.5.6",
-      "targets": [
-        {
-          "database": "hotfix01-metricsdb",
-          "datasource": {
-            "type": "grafana-azure-data-explorer-datasource",
-            "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-          },
-          "expression": {
-            "from": {
-              "property": {
-                "name": "Aksservernode_Availability",
-                "type": "string"
-              },
-              "type": "property"
-            },
-            "groupBy": {
-              "expressions": [],
-              "type": "and"
-            },
-            "reduce": {
-              "expressions": [],
-              "type": "and"
-            },
-            "where": {
-              "expressions": [],
-              "type": "and"
-            }
-          },
-          "pluginVersion": "4.4.1",
-          "query": "Aksservernode_Availability\n| where $__timeFilter(['date']) and location in ($Region) and subscriptionId in ($Subscriptions)\n| summarize dcount(id)",
-          "querySource": "raw",
-          "queryType": "KQL",
-          "rawMode": true,
-          "refId": "A",
-          "resultFormat": "table"
-        }
-      ],
-      "title": "Total # of Aks Server Nodes",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "grafana-azure-data-explorer-datasource",
-        "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 8,
-        "y": 3
-      },
-      "id": 20,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.5.6",
-      "targets": [
-        {
-          "database": "hotfix01-metricsdb",
-          "datasource": {
-            "type": "grafana-azure-data-explorer-datasource",
-            "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-          },
-          "expression": {
-            "from": {
-              "property": {
-                "name": "Loadbalancer_Availability",
-                "type": "string"
-              },
-              "type": "property"
-            },
-            "groupBy": {
-              "expressions": [],
-              "type": "and"
-            },
-            "reduce": {
-              "expressions": [],
-              "type": "and"
-            },
-            "where": {
-              "expressions": [],
-              "type": "and"
-            }
-          },
-          "pluginVersion": "4.5.0",
-          "query": "Loadbalancer_Availability\n| where $__timeFilter(['date']) and location in ($Region) and subscriptionId in ($Subscriptions)\n| summarize dcount(id)",
-          "querySource": "raw",
-          "queryType": "KQL",
-          "rawMode": true,
-          "refId": "A",
-          "resultFormat": "table"
-        }
-      ],
-      "title": "Total # of Load Balancers",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "grafana-azure-data-explorer-datasource",
-        "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 12,
-        "y": 3
-      },
-      "id": 16,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.5.6",
-      "targets": [
-        {
-          "database": "hotfix01-metricsdb",
-          "datasource": {
-            "type": "grafana-azure-data-explorer-datasource",
-            "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-          },
-          "expression": {
-            "from": {
-              "property": {
-                "name": "Firewall_Availability",
-                "type": "string"
-              },
-              "type": "property"
-            },
-            "groupBy": {
-              "expressions": [],
-              "type": "and"
-            },
-            "reduce": {
-              "expressions": [],
-              "type": "and"
-            },
-            "where": {
-              "expressions": [],
-              "type": "and"
-            }
-          },
-          "pluginVersion": "4.2.0",
-          "query": "Firewall_Availability\n| where $__timeFilter(['date']) and location in ($Region) and subscriptionId in ($Subscriptions)\n| summarize dcount(id)",
-          "querySource": "raw",
-          "rawMode": true,
-          "refId": "A",
-          "resultFormat": "table"
-        }
-      ],
-      "title": "Total # of Firewalls",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "grafana-azure-data-explorer-datasource",
-        "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 16,
-        "y": 3
-      },
-      "id": 4,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.5.6",
-      "targets": [
-        {
-          "database": "hotfix01-metricsdb",
-          "datasource": {
-            "type": "grafana-azure-data-explorer-datasource",
-            "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-          },
-          "expression": {
-            "from": {
-              "property": {
-                "name": "Cosmosdb_Availability",
-                "type": "string"
-              },
-              "type": "property"
-            },
-            "groupBy": {
-              "expressions": [],
-              "type": "and"
-            },
-            "reduce": {
-              "expressions": [],
-              "type": "and"
-            },
-            "where": {
-              "expressions": [],
-              "type": "and"
-            }
-          },
-          "pluginVersion": "4.2.0",
-          "query": "Cosmosdb_Availability\n| where $__timeFilter(['date']) and location in ($Region) and subscriptionId in ($Subscriptions)\n| summarize dcount(id)",
-          "querySource": "raw",
-          "rawMode": true,
-          "refId": "A",
-          "resultFormat": "table"
-        }
-      ],
-      "title": "Total # of Cosmos DBs",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "grafana-azure-data-explorer-datasource",
-        "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 0,
-        "y": 6
-      },
-      "id": 18,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.5.6",
-      "targets": [
-        {
-          "database": "hotfix01-metricsdb",
-          "datasource": {
-            "type": "grafana-azure-data-explorer-datasource",
-            "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-          },
-          "expression": {
-            "from": {
-              "property": {
-                "name": "Keyvault_Availability",
-                "type": "string"
-              },
-              "type": "property"
-            },
-            "groupBy": {
-              "expressions": [],
-              "type": "and"
-            },
-            "reduce": {
-              "expressions": [],
-              "type": "and"
-            },
-            "where": {
-              "expressions": [],
-              "type": "and"
-            }
-          },
-          "pluginVersion": "4.2.0",
-          "query": "Keyvault_Availability\n| where $__timeFilter(['date']) and location in ($Region) and subscriptionId in ($Subscriptions)\n| summarize dcount(id)",
-          "querySource": "raw",
-          "rawMode": true,
-          "refId": "A",
-          "resultFormat": "table"
-        }
-      ],
-      "title": "Total # of Keyvaults",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "grafana-azure-data-explorer-datasource",
-        "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 4,
-        "y": 6
-      },
-      "id": 44,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.5.6",
-      "targets": [
-        {
-          "database": "hotfix01-metricsdb",
-          "datasource": {
-            "type": "grafana-azure-data-explorer-datasource",
-            "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-          },
-          "expression": {
-            "from": {
-              "property": {
-                "name": "Keyvault_Availability",
-                "type": "string"
-              },
-              "type": "property"
-            },
-            "groupBy": {
-              "expressions": [],
-              "type": "and"
-            },
-            "reduce": {
-              "expressions": [],
-              "type": "and"
-            },
-            "where": {
-              "expressions": [],
-              "type": "and"
-            }
-          },
-          "pluginVersion": "4.4.1",
-          "query": "Eventhubs_Availability\n| where $__timeFilter(['date']) and location in ($Region) and subscriptionId in ($Subscriptions)\n| summarize dcount(id)",
-          "querySource": "raw",
-          "queryType": "KQL",
-          "rawMode": true,
-          "refId": "A",
-          "resultFormat": "table"
-        }
-      ],
-      "title": "Total # of Eventhubs",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "grafana-azure-data-explorer-datasource",
-        "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 8,
-        "y": 6
-      },
-      "id": 42,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.5.6",
-      "targets": [
-        {
-          "database": "hotfix01-metricsdb",
-          "datasource": {
-            "type": "grafana-azure-data-explorer-datasource",
-            "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-          },
-          "expression": {
-            "from": {
-              "property": {
-                "name": "Keyvault_Availability",
-                "type": "string"
-              },
-              "type": "property"
-            },
-            "groupBy": {
-              "expressions": [],
-              "type": "and"
-            },
-            "reduce": {
-              "expressions": [],
-              "type": "and"
-            },
-            "where": {
-              "expressions": [],
-              "type": "and"
-            }
-          },
-          "pluginVersion": "4.4.1",
-          "query": "Cognitive_Svc_Availability\n| where $__timeFilter(['date']) and location in ($Region) and subscriptionId in ($Subscriptions)\n| summarize dcount(id)",
-          "querySource": "raw",
-          "queryType": "KQL",
-          "rawMode": true,
-          "refId": "A",
-          "resultFormat": "table"
-        }
-      ],
-      "title": "Total # of Cognitive Services",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "grafana-azure-data-explorer-datasource",
-        "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 12,
-        "y": 6
-      },
-      "id": 43,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.5.6",
-      "targets": [
-        {
-          "database": "hotfix01-metricsdb",
-          "datasource": {
-            "type": "grafana-azure-data-explorer-datasource",
-            "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-          },
-          "expression": {
-            "from": {
-              "property": {
-                "name": "Keyvault_Availability",
-                "type": "string"
-              },
-              "type": "property"
-            },
-            "groupBy": {
-              "expressions": [],
-              "type": "and"
-            },
-            "reduce": {
-              "expressions": [],
-              "type": "and"
-            },
-            "where": {
-              "expressions": [],
-              "type": "and"
-            }
-          },
-          "pluginVersion": "4.4.1",
-          "query": "Container_Registry_Availability\n| where $__timeFilter(['date']) and location in ($Region) and subscriptionId in ($Subscriptions)\n| summarize dcount(id)",
-          "querySource": "raw",
-          "queryType": "KQL",
-          "rawMode": true,
-          "refId": "A",
-          "resultFormat": "table"
-        }
-      ],
-      "title": "Total # of Container Registries",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "grafana-azure-data-explorer-datasource",
-        "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 16,
-        "y": 6
-      },
-      "id": 45,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.5.6",
-      "targets": [
-        {
-          "database": "hotfix01-metricsdb",
-          "datasource": {
-            "type": "grafana-azure-data-explorer-datasource",
-            "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-          },
-          "expression": {
-            "from": {
-              "property": {
-                "name": "Keyvault_Availability",
-                "type": "string"
-              },
-              "type": "property"
-            },
-            "groupBy": {
-              "expressions": [],
-              "type": "and"
-            },
-            "reduce": {
-              "expressions": [],
-              "type": "and"
-            },
-            "where": {
-              "expressions": [],
-              "type": "and"
-            }
-          },
-          "pluginVersion": "4.4.1",
-          "query": "LogAnalytics_Availability\n| where $__timeFilter(['date']) and location in ($Region) and subscriptionId in ($Subscriptions)\n| summarize dcount(id)",
-          "querySource": "raw",
-          "queryType": "KQL",
-          "rawMode": true,
-          "refId": "A",
-          "resultFormat": "table"
-        }
-      ],
-      "title": "Total # of Log Analytics",
-      "type": "stat"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 9
-      },
-      "id": 6,
-      "panels": [],
-      "title": "Compute",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "grafana-azure-data-explorer-datasource",
-        "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-      },
-      "description": "Availability metric - https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftcontainerservicemanagedclusters",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": true,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineStyle": {
-              "fill": "solid"
-            },
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "decimals": 3,
-          "links": [
+    "annotations": {
+        "list": [
             {
-              "targetBlank": true,
-              "title": "aksservernode drill down details",
-              "url": "https://hotfix01-grafana-e0hudyfcbbbudgd7.eus.grafana.azure.com/d/OD9S0za4z/aksservernode?orgId=1${__url_time_range}&var-selecteddate=${__data.fields.date}&${Region:queryparam}&${Subscriptions:queryparam}&${Solution:queryparam}"
+                "builtIn": 1,
+                "datasource": {
+                    "type": "grafana",
+                    "uid": "-- Grafana --"
+                },
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "target": {
+                    "limit": 100,
+                    "matchAny": false,
+                    "tags": [],
+                    "type": "dashboard"
+                },
+                "type": "dashboard"
             }
-          ],
-          "mappings": [],
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 10,
-        "x": 0,
-        "y": 10
-      },
-      "id": 23,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "database": "hotfix01-metricsdb",
-          "datasource": {
-            "type": "grafana-azure-data-explorer-datasource",
-            "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-          },
-          "expression": {
-            "from": {
-              "property": {
-                "name": "Aksservernode_Availability",
-                "type": "string"
-              },
-              "type": "property"
-            },
-            "groupBy": {
-              "expressions": [],
-              "type": "and"
-            },
-            "reduce": {
-              "expressions": [],
-              "type": "and"
-            },
-            "where": {
-              "expressions": [],
-              "type": "and"
-            }
-          },
-          "pluginVersion": "4.2.0",
-          "query": "Subscriptions\n|join Aksservernode_Availability on subscriptionId\n| project component, createdAt, ['date'], id, location, name, nodeNotReady,\n nodeReady, nodeUnknown,solution, subscriptionId,tenancy, availability = ((nodeReady )/(nodeNotReady +nodeReady))*100\n| where $__timeFilter(['date'])\n and location in ($Region) and subscriptionId in ($Subscriptions)\n and solution in ($Solution)\n| summarize aksservernode = (avg(availability)) by ['date']",
-          "querySource": "raw",
-          "rawMode": true,
-          "refId": "A",
-          "resultFormat": "table"
-        }
-      ],
-      "title": "AKS Server Node Avg [(readynode/(readynode+notready))*100]",
-      "type": "timeseries"
+        ]
     },
-    {
-      "datasource": {
-        "type": "grafana-azure-data-explorer-datasource",
-        "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-      },
-      "description": "Availability metric - https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftcontainerservicemanagedclusters",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 29,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+        {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
             },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
+            "id": 2,
+            "panels": [],
+            "title": "Resource inventory in selected period",
+            "type": "row"
+        },
+        {
+            "datasource": {
+                "type": "grafana-azure-data-explorer-datasource",
+                "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
             },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
+            "gridPos": {
+                "h": 2,
+                "w": 20,
+                "x": 0,
+                "y": 1
             },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "decimals": 3,
-          "links": [
+            "id": 21,
+            "options": {
+                "code": {
+                    "language": "plaintext",
+                    "showLineNumbers": false,
+                    "showMiniMap": false
+                },
+                "content": "Avg availability of services shown here includes data from all events (platform caused and user errors)",
+                "mode": "markdown"
+            },
+            "pluginVersion": "9.5.6",
+            "targets": [
+                {
+                    "database": "sk001-metricsdb",
+                    "datasource": {
+                        "type": "grafana-azure-data-explorer-datasource",
+                        "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                    },
+                    "expression": {
+                        "from": {
+                            "property": {
+                                "name": "vm_availability",
+                                "type": "string"
+                            },
+                            "type": "property"
+                        },
+                        "groupBy": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "reduce": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "where": {
+                            "expressions": [],
+                            "type": "and"
+                        }
+                    },
+                    "pluginVersion": "4.2.0",
+                    "query": "loadbalancer_availability\n| where $__timeFilter(['date'])// and region  in ($Region)\n| summarize dcount(id)",
+                    "querySource": "raw",
+                    "rawMode": true,
+                    "refId": "A",
+                    "resultFormat": "table"
+                }
+            ],
+            "title": "Note",
+            "type": "text"
+        },
+        {
+            "datasource": {
+                "type": "grafana-azure-data-explorer-datasource",
+                "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 0,
+                "y": 3
+            },
+            "id": 17,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.5.6",
+            "targets": [
+                {
+                    "database": "sk001-metricsdb",
+                    "datasource": {
+                        "type": "grafana-azure-data-explorer-datasource",
+                        "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                    },
+                    "expression": {
+                        "from": {
+                            "property": {
+                                "name": "Storage_Availability",
+                                "type": "string"
+                            },
+                            "type": "property"
+                        },
+                        "groupBy": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "reduce": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "where": {
+                            "expressions": [],
+                            "type": "and"
+                        }
+                    },
+                    "pluginVersion": "4.2.0",
+                    "query": "Storage_Availability\n| where $__timeFilter(['date']) and location in ($Region) and subscriptionId in ($Subscriptions)\n| summarize dcount(id)",
+                    "querySource": "raw",
+                    "rawMode": true,
+                    "refId": "A",
+                    "resultFormat": "table"
+                }
+            ],
+            "title": "Total # of Storage",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "grafana-azure-data-explorer-datasource",
+                "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 4,
+                "y": 3
+            },
+            "id": 30,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.5.6",
+            "targets": [
+                {
+                    "database": "sk001-metricsdb",
+                    "datasource": {
+                        "type": "grafana-azure-data-explorer-datasource",
+                        "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                    },
+                    "expression": {
+                        "from": {
+                            "property": {
+                                "name": "Aksservernode_Availability",
+                                "type": "string"
+                            },
+                            "type": "property"
+                        },
+                        "groupBy": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "reduce": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "where": {
+                            "expressions": [],
+                            "type": "and"
+                        }
+                    },
+                    "pluginVersion": "4.4.1",
+                    "query": "Aksservernode_Availability\n| where $__timeFilter(['date']) and location in ($Region) and subscriptionId in ($Subscriptions)\n| summarize dcount(id)",
+                    "querySource": "raw",
+                    "queryType": "KQL",
+                    "rawMode": true,
+                    "refId": "A",
+                    "resultFormat": "table"
+                }
+            ],
+            "title": "Total # of Aks Server Nodes",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "grafana-azure-data-explorer-datasource",
+                "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 8,
+                "y": 3
+            },
+            "id": 20,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.5.6",
+            "targets": [
+                {
+                    "database": "sk001-metricsdb",
+                    "datasource": {
+                        "type": "grafana-azure-data-explorer-datasource",
+                        "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                    },
+                    "expression": {
+                        "from": {
+                            "property": {
+                                "name": "Loadbalancer_Availability",
+                                "type": "string"
+                            },
+                            "type": "property"
+                        },
+                        "groupBy": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "reduce": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "where": {
+                            "expressions": [],
+                            "type": "and"
+                        }
+                    },
+                    "pluginVersion": "4.5.0",
+                    "query": "Loadbalancer_Availability\n| where $__timeFilter(['date']) and location in ($Region) and subscriptionId in ($Subscriptions)\n| summarize dcount(id)",
+                    "querySource": "raw",
+                    "queryType": "KQL",
+                    "rawMode": true,
+                    "refId": "A",
+                    "resultFormat": "table"
+                }
+            ],
+            "title": "Total # of Load Balancers",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "grafana-azure-data-explorer-datasource",
+                "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 12,
+                "y": 3
+            },
+            "id": 16,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.5.6",
+            "targets": [
+                {
+                    "database": "sk001-metricsdb",
+                    "datasource": {
+                        "type": "grafana-azure-data-explorer-datasource",
+                        "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                    },
+                    "expression": {
+                        "from": {
+                            "property": {
+                                "name": "Firewall_Availability",
+                                "type": "string"
+                            },
+                            "type": "property"
+                        },
+                        "groupBy": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "reduce": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "where": {
+                            "expressions": [],
+                            "type": "and"
+                        }
+                    },
+                    "pluginVersion": "4.2.0",
+                    "query": "Firewall_Availability\n| where $__timeFilter(['date']) and location in ($Region) and subscriptionId in ($Subscriptions)\n| summarize dcount(id)",
+                    "querySource": "raw",
+                    "rawMode": true,
+                    "refId": "A",
+                    "resultFormat": "table"
+                }
+            ],
+            "title": "Total # of Firewalls",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "grafana-azure-data-explorer-datasource",
+                "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 16,
+                "y": 3
+            },
+            "id": 4,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.5.6",
+            "targets": [
+                {
+                    "database": "sk001-metricsdb",
+                    "datasource": {
+                        "type": "grafana-azure-data-explorer-datasource",
+                        "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                    },
+                    "expression": {
+                        "from": {
+                            "property": {
+                                "name": "Cosmosdb_Availability",
+                                "type": "string"
+                            },
+                            "type": "property"
+                        },
+                        "groupBy": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "reduce": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "where": {
+                            "expressions": [],
+                            "type": "and"
+                        }
+                    },
+                    "pluginVersion": "4.2.0",
+                    "query": "Cosmosdb_Availability\n| where $__timeFilter(['date']) and location in ($Region) and subscriptionId in ($Subscriptions)\n| summarize dcount(id)",
+                    "querySource": "raw",
+                    "rawMode": true,
+                    "refId": "A",
+                    "resultFormat": "table"
+                }
+            ],
+            "title": "Total # of Cosmos DBs",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "grafana-azure-data-explorer-datasource",
+                "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 0,
+                "y": 6
+            },
+            "id": 18,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.5.6",
+            "targets": [
+                {
+                    "database": "sk001-metricsdb",
+                    "datasource": {
+                        "type": "grafana-azure-data-explorer-datasource",
+                        "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                    },
+                    "expression": {
+                        "from": {
+                            "property": {
+                                "name": "Keyvault_Availability",
+                                "type": "string"
+                            },
+                            "type": "property"
+                        },
+                        "groupBy": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "reduce": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "where": {
+                            "expressions": [],
+                            "type": "and"
+                        }
+                    },
+                    "pluginVersion": "4.2.0",
+                    "query": "Keyvault_Availability\n| where $__timeFilter(['date']) and location in ($Region) and subscriptionId in ($Subscriptions)\n| summarize dcount(id)",
+                    "querySource": "raw",
+                    "rawMode": true,
+                    "refId": "A",
+                    "resultFormat": "table"
+                }
+            ],
+            "title": "Total # of Keyvaults",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "grafana-azure-data-explorer-datasource",
+                "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 4,
+                "y": 6
+            },
+            "id": 44,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.5.6",
+            "targets": [
+                {
+                    "database": "sk001-metricsdb",
+                    "datasource": {
+                        "type": "grafana-azure-data-explorer-datasource",
+                        "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                    },
+                    "expression": {
+                        "from": {
+                            "property": {
+                                "name": "Keyvault_Availability",
+                                "type": "string"
+                            },
+                            "type": "property"
+                        },
+                        "groupBy": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "reduce": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "where": {
+                            "expressions": [],
+                            "type": "and"
+                        }
+                    },
+                    "pluginVersion": "4.4.1",
+                    "query": "Eventhubs_Availability\n| where $__timeFilter(['date']) and location in ($Region) and subscriptionId in ($Subscriptions)\n| summarize dcount(id)",
+                    "querySource": "raw",
+                    "queryType": "KQL",
+                    "rawMode": true,
+                    "refId": "A",
+                    "resultFormat": "table"
+                }
+            ],
+            "title": "Total # of Eventhubs",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "grafana-azure-data-explorer-datasource",
+                "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 8,
+                "y": 6
+            },
+            "id": 42,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.5.6",
+            "targets": [
+                {
+                    "database": "sk001-metricsdb",
+                    "datasource": {
+                        "type": "grafana-azure-data-explorer-datasource",
+                        "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                    },
+                    "expression": {
+                        "from": {
+                            "property": {
+                                "name": "Keyvault_Availability",
+                                "type": "string"
+                            },
+                            "type": "property"
+                        },
+                        "groupBy": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "reduce": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "where": {
+                            "expressions": [],
+                            "type": "and"
+                        }
+                    },
+                    "pluginVersion": "4.4.1",
+                    "query": "Cognitive_Svc_Availability\n| where $__timeFilter(['date']) and location in ($Region) and subscriptionId in ($Subscriptions)\n| summarize dcount(id)",
+                    "querySource": "raw",
+                    "queryType": "KQL",
+                    "rawMode": true,
+                    "refId": "A",
+                    "resultFormat": "table"
+                }
+            ],
+            "title": "Total # of Cognitive Services",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "grafana-azure-data-explorer-datasource",
+                "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 12,
+                "y": 6
+            },
+            "id": 43,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.5.6",
+            "targets": [
+                {
+                    "database": "sk001-metricsdb",
+                    "datasource": {
+                        "type": "grafana-azure-data-explorer-datasource",
+                        "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                    },
+                    "expression": {
+                        "from": {
+                            "property": {
+                                "name": "Keyvault_Availability",
+                                "type": "string"
+                            },
+                            "type": "property"
+                        },
+                        "groupBy": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "reduce": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "where": {
+                            "expressions": [],
+                            "type": "and"
+                        }
+                    },
+                    "pluginVersion": "4.4.1",
+                    "query": "Container_Registry_Availability\n| where $__timeFilter(['date']) and location in ($Region) and subscriptionId in ($Subscriptions)\n| summarize dcount(id)",
+                    "querySource": "raw",
+                    "queryType": "KQL",
+                    "rawMode": true,
+                    "refId": "A",
+                    "resultFormat": "table"
+                }
+            ],
+            "title": "Total # of Container Registries",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "grafana-azure-data-explorer-datasource",
+                "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 16,
+                "y": 6
+            },
+            "id": 45,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "9.5.6",
+            "targets": [
+                {
+                    "database": "sk001-metricsdb",
+                    "datasource": {
+                        "type": "grafana-azure-data-explorer-datasource",
+                        "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                    },
+                    "expression": {
+                        "from": {
+                            "property": {
+                                "name": "Keyvault_Availability",
+                                "type": "string"
+                            },
+                            "type": "property"
+                        },
+                        "groupBy": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "reduce": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "where": {
+                            "expressions": [],
+                            "type": "and"
+                        }
+                    },
+                    "pluginVersion": "4.4.1",
+                    "query": "LogAnalytics_Availability\n| where $__timeFilter(['date']) and location in ($Region) and subscriptionId in ($Subscriptions)\n| summarize dcount(id)",
+                    "querySource": "raw",
+                    "queryType": "KQL",
+                    "rawMode": true,
+                    "refId": "A",
+                    "resultFormat": "table"
+                }
+            ],
+            "title": "Total # of Log Analytics",
+            "type": "stat"
+        },
+        {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 9
+            },
+            "id": 6,
+            "panels": [],
+            "title": "Compute",
+            "type": "row"
+        },
+        {
+            "datasource": {
+                "type": "grafana-azure-data-explorer-datasource",
+                "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+            },
+            "description": "Availability metric - https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftcontainerservicemanagedclusters",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": true,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineStyle": {
+                            "fill": "solid"
+                        },
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "decimals": 3,
+                    "links": [
+                        {
+                            "targetBlank": true,
+                            "title": "aksservernode drill down details",
+                            "url": "https://sk001-grafana-g6evdeghaebqdsat.eus.grafana.azure.com/d/OD9S0za4z/aksservernode?orgId=1${__url_time_range}&var-selecteddate=${__data.fields.date}&${Region:queryparam}&${Subscriptions:queryparam}&${Solution:queryparam}"
+                        }
+                    ],
+                    "mappings": [],
+                    "min": 0,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 10,
+                "x": 0,
+                "y": 10
+            },
+            "id": 23,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "database": "sk001-metricsdb",
+                    "datasource": {
+                        "type": "grafana-azure-data-explorer-datasource",
+                        "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                    },
+                    "expression": {
+                        "from": {
+                            "property": {
+                                "name": "Aksservernode_Availability",
+                                "type": "string"
+                            },
+                            "type": "property"
+                        },
+                        "groupBy": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "reduce": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "where": {
+                            "expressions": [],
+                            "type": "and"
+                        }
+                    },
+                    "pluginVersion": "4.2.0",
+                    "query": "Subscriptions\n|join Aksservernode_Availability on subscriptionId\n| project component, createdAt, ['date'], id, location, name, nodeNotReady,\n nodeReady, nodeUnknown,solution, subscriptionId,tenancy, availability = ((nodeReady )/(nodeNotReady +nodeReady))*100\n| where $__timeFilter(['date'])\n and location in ($Region) and subscriptionId in ($Subscriptions)\n and solution in ($Solution)\n| summarize aksservernode = (avg(availability)) by ['date']",
+                    "querySource": "raw",
+                    "rawMode": true,
+                    "refId": "A",
+                    "resultFormat": "table"
+                }
+            ],
+            "title": "AKS Server Node Avg [(readynode/(readynode+notready))*100]",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "grafana-azure-data-explorer-datasource",
+                "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+            },
+            "description": "Availability metric - https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftcontainerservicemanagedclusters",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "decimals": 3,
+                    "links": [
+                        {
+                            "targetBlank": true,
+                            "title": "acr drill down details",
+                            "url": "https://sk001-grafana-g6evdeghaebqdsat.eus.grafana.azure.com/d/mBHFSeX4z/containerregistry?orgId=1${__url_time_range}&var-selecteddate=${__data.fields.date}&${Region:queryparam}&${Subscriptions:queryparam}&${Solution:queryparam}"
+                        }
+                    ],
+                    "mappings": [],
+                    "max": 100,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 10,
+                "x": 10,
+                "y": 10
+            },
+            "id": 37,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "database": "sk001-metricsdb",
+                    "datasource": {
+                        "type": "grafana-azure-data-explorer-datasource",
+                        "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                    },
+                    "expression": {
+                        "from": {
+                            "property": {
+                                "name": "Container_Registry_Availability",
+                                "type": "string"
+                            },
+                            "type": "property"
+                        },
+                        "groupBy": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "reduce": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "where": {
+                            "expressions": [],
+                            "type": "and"
+                        }
+                    },
+                    "pluginVersion": "4.4.1",
+                    "query": "Subscriptions\n|join Container_Registry_Availability on subscriptionId\n| where $__timeFilter(['date']) and isnotnull(successfulPullCount) and isnotnull(totalPullCount) and isnotnull(successfulPushCount) and isnotnull(totalPushCount)\n and location in ($Region) and subscriptionId in ($Subscriptions)\n and solution in ($Solution)\n| summarize acr = avg(((successfulPullCount+successfulPushCount)/(totalPullCount+totalPushCount))*100) by ['date']",
+                    "querySource": "raw",
+                    "queryType": "KQL",
+                    "rawMode": true,
+                    "refId": "A",
+                    "resultFormat": "table"
+                }
+            ],
+            "title": "Container Registry Avg [((successfulPull+successfulPush)/(totalPullCount+totalPushCount))*100]",
+            "type": "timeseries"
+        },
+        {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 17
+            },
+            "id": 8,
+            "panels": [],
+            "title": "Storage",
+            "type": "row"
+        },
+        {
+            "datasource": {
+                "type": "grafana-azure-data-explorer-datasource",
+                "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+            },
+            "description": "Availability metric - https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftstoragestorageaccounts",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "decimals": 3,
+                    "links": [
+                        {
+                            "targetBlank": true,
+                            "title": "storage drill down details",
+                            "url": "https://sk001-grafana-g6evdeghaebqdsat.eus.grafana.azure.com/d/e90a362b-0e3e-4da7-a725-0f35415d18bc/storage?orgId=1${__url_time_range}&var-selecteddate=${__data.fields.date}&${Region:queryparam}&${Subscriptions:queryparam}&${Solution:queryparam}"
+                        }
+                    ],
+                    "mappings": [],
+                    "max": 100,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "dark-red",
+                                "value": null
+                            },
+                            {
+                                "color": "dark-green",
+                                "value": 100
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 10,
+                "x": 0,
+                "y": 18
+            },
+            "id": 25,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "database": "sk001-metricsdb",
+                    "datasource": {
+                        "type": "grafana-azure-data-explorer-datasource",
+                        "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                    },
+                    "expression": {
+                        "from": {
+                            "property": {
+                                "name": "Storage_Availability",
+                                "type": "string"
+                            },
+                            "type": "property"
+                        },
+                        "groupBy": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "reduce": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "where": {
+                            "expressions": [],
+                            "type": "and"
+                        }
+                    },
+                    "pluginVersion": "4.4.1",
+                    "query": "Subscriptions\n|join Storage_Availability on subscriptionId\n| where $__timeFilter(['date']) and isnotnull(availability)\n and location in ($Region) and subscriptionId in ($Subscriptions)\n and solution in ($Solution)\n| summarize storage = (avg(availability)) by ['date']",
+                    "querySource": "raw",
+                    "queryType": "KQL",
+                    "rawMode": true,
+                    "refId": "A",
+                    "resultFormat": "table"
+                }
+            ],
+            "title": "Storage Avg [Successful Tx / All Tx]",
+            "type": "timeseries"
+        },
+        {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 25
+            },
+            "id": 10,
+            "panels": [],
+            "title": "Networking",
+            "type": "row"
+        },
+        {
+            "datasource": {
+                "type": "grafana-azure-data-explorer-datasource",
+                "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+            },
+            "description": "Availability metric - https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftnetworkazurefirewalls",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "decimals": 3,
+                    "links": [
+                        {
+                            "targetBlank": true,
+                            "title": "loadbalancer drill down details",
+                            "url": "https://sk001-grafana-g6evdeghaebqdsat.eus.grafana.azure.com/d/edbbddfb-a8d7-4b5d-bfa4-9703ac678f2b/loadbalancer?orgId=1${__url_time_range}&var-selecteddate=${__data.fields.date}&${Region:queryparam}&${Subscriptions:queryparam}&${Solution:queryparam}"
+                        }
+                    ],
+                    "mappings": [],
+                    "max": 100,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 10,
+                "x": 0,
+                "y": 26
+            },
+            "id": 31,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "database": "sk001-metricsdb",
+                    "datasource": {
+                        "type": "grafana-azure-data-explorer-datasource",
+                        "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                    },
+                    "expression": {
+                        "from": {
+                            "property": {
+                                "name": "Loadbalancer_Availability",
+                                "type": "string"
+                            },
+                            "type": "property"
+                        },
+                        "groupBy": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "reduce": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "where": {
+                            "expressions": [],
+                            "type": "and"
+                        }
+                    },
+                    "pluginVersion": "4.5.0",
+                    "query": "Subscriptions\n|join Loadbalancer_Availability on subscriptionId\n| where $__timeFilter(['date']) and isnotnull(availability)\n and location in ($Region) and subscriptionId in ($Subscriptions)\n and solution in ($Solution)\n| summarize loadbalancer = (avg(availability)) by ['date']",
+                    "querySource": "raw",
+                    "queryType": "KQL",
+                    "rawMode": true,
+                    "refId": "A",
+                    "resultFormat": "table"
+                }
+            ],
+            "title": "Load Balancer Avg [Successful Tx / All Tx]",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "grafana-azure-data-explorer-datasource",
+                "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+            },
+            "description": "Availability metric -https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftnetworkazurefirewalls",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "decimals": 3,
+                    "links": [
+                        {
+                            "targetBlank": true,
+                            "title": "firewall drill down details",
+                            "url": "https://sk001-grafana-g6evdeghaebqdsat.eus.grafana.azure.com/d/8HDuNUC4z/firewalls?orgId=1${__url_time_range}&var-selecteddate=${__data.fields.date}&${Region:queryparam}&${Subscriptions:queryparam}&${Solution:queryparam}"
+                        }
+                    ],
+                    "mappings": [],
+                    "max": 100,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 10,
+                "x": 10,
+                "y": 26
+            },
+            "id": 26,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "database": "sk001-metricsdb",
+                    "datasource": {
+                        "type": "grafana-azure-data-explorer-datasource",
+                        "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                    },
+                    "expression": {
+                        "from": {
+                            "property": {
+                                "name": "Firewall_Availability",
+                                "type": "string"
+                            },
+                            "type": "property"
+                        },
+                        "groupBy": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "reduce": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "where": {
+                            "expressions": [],
+                            "type": "and"
+                        }
+                    },
+                    "pluginVersion": "4.5.0",
+                    "query": "Subscriptions\n|join Firewall_Availability on subscriptionId\n| where $__timeFilter(['date']) and isnotnull(availability)\n and location in ($Region) and subscriptionId in ($Subscriptions)\n and solution in ($Solution)\n| summarize firewall = (avg(availability)) by ['date']",
+                    "querySource": "raw",
+                    "queryType": "KQL",
+                    "rawMode": true,
+                    "refId": "A",
+                    "resultFormat": "table"
+                }
+            ],
+            "title": "Firewall Avg [Successful Tx / All Tx]",
+            "type": "timeseries"
+        },
+        {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 33
+            },
+            "id": 12,
+            "panels": [],
+            "title": "Databases",
+            "type": "row"
+        },
+        {
+            "datasource": {
+                "type": "grafana-azure-data-explorer-datasource",
+                "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+            },
+            "description": "availability metric - https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftdocumentdbdatabaseaccounts",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "decimals": 3,
+                    "links": [
+                        {
+                            "targetBlank": true,
+                            "title": "cosmosdb drill down details",
+                            "url": "https://sk001-grafana-g6evdeghaebqdsat.eus.grafana.azure.com/d/a05004e1-8d3f-4e62-90e2-293853b8e41e/cosmosdb-details?orgId=1${__url_time_range}&var-selecteddate=${__data.fields.date}&${Region:queryparam}&${Subscriptions:queryparam}&${Solution:queryparam}"
+                        }
+                    ],
+                    "mappings": [],
+                    "max": 100,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green"
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 10,
+                "x": 0,
+                "y": 34
+            },
+            "id": 28,
+            "links": [],
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "database": "sk001-metricsdb",
+                    "datasource": {
+                        "type": "grafana-azure-data-explorer-datasource",
+                        "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                    },
+                    "expression": {
+                        "from": {
+                            "property": {
+                                "name": "Cosmosdb_Availability",
+                                "type": "string"
+                            },
+                            "type": "property"
+                        },
+                        "groupBy": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "reduce": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "where": {
+                            "expressions": [],
+                            "type": "and"
+                        }
+                    },
+                    "pluginVersion": "4.5.0",
+                    "query": "Subscriptions\n|join Cosmosdb_Availability on subscriptionId\n| where $__timeFilter(['date']) and isnotnull(availability)\n and location in ($Region) and subscriptionId in ($Subscriptions)\n and solution in ($Solution)\n| summarize cosmosdb = (avg(availability)) by ['date']",
+                    "querySource": "raw",
+                    "queryType": "KQL",
+                    "rawMode": true,
+                    "refId": "A",
+                    "resultFormat": "table"
+                }
+            ],
+            "title": "Cosmos DB Avg [Successful Tx / All Tx]",
+            "type": "timeseries"
+        },
+        {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 41
+            },
+            "id": 14,
+            "panels": [],
+            "title": "Identity + Security",
+            "type": "row"
+        },
+        {
+            "datasource": {
+                "type": "grafana-azure-data-explorer-datasource",
+                "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+            },
+            "description": "availability metric - https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftdocumentdbdatabaseaccounts",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "decimals": 3,
+                    "links": [
+                        {
+                            "targetBlank": true,
+                            "title": "keyvault drill down details",
+                            "url": "https://sk001-grafana-g6evdeghaebqdsat.eus.grafana.azure.com/d/e3c65d8f-73f2-44db-a13e-2f37494d10a8/keyvault?orgId=1${__url_time_range}&var-selecteddate=${__data.fields.date}&${Region:queryparam}&${Subscriptions:queryparam}&${Solution:queryparam}"
+                        }
+                    ],
+                    "mappings": [],
+                    "max": 100,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green"
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 10,
+                "x": 0,
+                "y": 42
+            },
+            "id": 27,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "database": "sk001-metricsdb",
+                    "datasource": {
+                        "type": "grafana-azure-data-explorer-datasource",
+                        "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                    },
+                    "expression": {
+                        "from": {
+                            "property": {
+                                "name": "Keyvault_Availability",
+                                "type": "string"
+                            },
+                            "type": "property"
+                        },
+                        "groupBy": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "reduce": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "where": {
+                            "expressions": [],
+                            "type": "and"
+                        }
+                    },
+                    "pluginVersion": "4.5.0",
+                    "query": "Subscriptions\n|join Keyvault_Availability on subscriptionId\n| where $__timeFilter(['date']) and isnotnull(availability)\n and location in ($Region) and subscriptionId in ($Subscriptions)\n and solution in ($Solution)\n| summarize keyvault = (avg(availability)) by ['date']",
+                    "querySource": "raw",
+                    "queryType": "KQL",
+                    "rawMode": true,
+                    "refId": "A",
+                    "resultFormat": "table"
+                }
+            ],
+            "title": "Key Vault Avg [Successful Tx / All Tx]",
+            "type": "timeseries"
+        },
+        {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 49
+            },
+            "id": 33,
+            "panels": [],
+            "title": "AI + Machine Learning",
+            "type": "row"
+        },
+        {
+            "datasource": {
+                "type": "grafana-azure-data-explorer-datasource",
+                "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+            },
+            "description": "Availability metric - https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftcognitiveservicesaccounts",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "decimals": 3,
+                    "links": [
+                        {
+                            "targetBlank": true,
+                            "title": "cognitive service drill down details",
+                            "url": "https://sk001-grafana-g6evdeghaebqdsat.eus.grafana.azure.com/d/lyldI6u4z/cognitiveservices?orgId=1${__url_time_range}&var-selecteddate=${__data.fields.date}&${Region:queryparam}&${Subscriptions:queryparam}&${Solution:queryparam}"
+                        }
+                    ],
+                    "mappings": [],
+                    "max": 100,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green"
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 10,
+                "x": 0,
+                "y": 50
+            },
+            "id": 35,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "database": "sk001-metricsdb",
+                    "datasource": {
+                        "type": "grafana-azure-data-explorer-datasource",
+                        "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                    },
+                    "expression": {
+                        "from": {
+                            "property": {
+                                "name": "Aksservernode_Availability_Raw",
+                                "type": "string"
+                            },
+                            "type": "property"
+                        },
+                        "groupBy": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "reduce": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "where": {
+                            "expressions": [],
+                            "type": "and"
+                        }
+                    },
+                    "pluginVersion": "4.4.1",
+                    "query": "Subscriptions\r\n|join Cognitive_Svc_Availability on subscriptionId\r\n| where $__timeFilter(['date']) and isnotnull(availability)\r\n and location in ($Region) and subscriptionId in ($Subscriptions)\r\n and solution in ($Solution)\r\n| summarize csa = (avg(availability)) by ['date']",
+                    "querySource": "raw",
+                    "queryType": "KQL",
+                    "rawMode": true,
+                    "refId": "A",
+                    "resultFormat": "table"
+                }
+            ],
+            "title": "Cognitive Services [Successful Tx / All Tx]",
+            "type": "timeseries"
+        },
+        {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 57
+            },
+            "id": 39,
+            "panels": [],
+            "title": "Analytics",
+            "type": "row"
+        },
+        {
+            "datasource": {
+                "type": "grafana-azure-data-explorer-datasource",
+                "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+            },
+            "description": "Availability metric - https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsofteventhubnamespaces",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "decimals": 3,
+                    "links": [
+                        {
+                            "targetBlank": true,
+                            "title": "eventhubs drill down details",
+                            "url": "https://sk001-grafana-g6evdeghaebqdsat.eus.grafana.azure.com/d/K9cdIeu4z/eventhubs?orgId=1${__url_time_range}&var-selecteddate=${__data.fields.date}&${Region:queryparam}&${Subscriptions:queryparam}&${Solution:queryparam}"
+                        }
+                    ],
+                    "mappings": [],
+                    "max": 100,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green"
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 10,
+                "x": 0,
+                "y": 58
+            },
+            "id": 41,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "database": "sk001-metricsdb",
+                    "datasource": {
+                        "type": "grafana-azure-data-explorer-datasource",
+                        "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                    },
+                    "expression": {
+                        "from": {
+                            "property": {
+                                "name": "Aksservernode_Availability_Raw",
+                                "type": "string"
+                            },
+                            "type": "property"
+                        },
+                        "groupBy": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "reduce": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "where": {
+                            "expressions": [],
+                            "type": "and"
+                        }
+                    },
+                    "pluginVersion": "4.4.1",
+                    "query": "Subscriptions\r\n|join Eventhubs_Availability on subscriptionId\r\n| where $__timeFilter(['date']) and isnotnull(incomingRequests) and isnotnull(serverErrors)\r\n and location in ($Region) and subscriptionId in ($Subscriptions)\r\n and solution in ($Solution)\r\n| summarize eventhubs = avg((incomingRequests-serverErrors)/incomingRequests)*100 by ['date']",
+                    "querySource": "raw",
+                    "queryType": "KQL",
+                    "rawMode": true,
+                    "refId": "A",
+                    "resultFormat": "table"
+                }
+            ],
+            "title": "Eventhubs [(incomingRequests-serverErrors)/incomingRequests)*100]",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "grafana-azure-data-explorer-datasource",
+                "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+            },
+            "description": "Availability metric - https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftoperationalinsightsworkspaces",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "decimals": 3,
+                    "links": [
+                        {
+                            "targetBlank": true,
+                            "title": "loganalytics drill down details",
+                            "url": "https://sk001-grafana-g6evdeghaebqdsat.eus.grafana.azure.com/d/mpNZfMr4k/loganalytics?orgId=1${__url_time_range}&var-selecteddate=${__data.fields.date}&${Region:queryparam}&${Subscriptions:queryparam}&${Solution:queryparam}"
+                        }
+                    ],
+                    "mappings": [],
+                    "max": 100,
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green"
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 10,
+                "x": 10,
+                "y": 58
+            },
+            "id": 46,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "database": "sk001-metricsdb",
+                    "datasource": {
+                        "type": "grafana-azure-data-explorer-datasource",
+                        "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                    },
+                    "expression": {
+                        "from": {
+                            "property": {
+                                "name": "Aksservernode_Availability_Raw",
+                                "type": "string"
+                            },
+                            "type": "property"
+                        },
+                        "groupBy": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "reduce": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "where": {
+                            "expressions": [],
+                            "type": "and"
+                        }
+                    },
+                    "pluginVersion": "4.4.1",
+                    "query": "Subscriptions\r\n|join LogAnalytics_Availability on subscriptionId\r\n| where $__timeFilter(['date']) and isnotnull(availability)\r\n and location in ($Region) and subscriptionId in ($Subscriptions)\r\n and solution in ($Solution)\r\n| summarize loganalytics = avg(availability) by ['date']",
+                    "querySource": "raw",
+                    "queryType": "KQL",
+                    "rawMode": true,
+                    "refId": "A",
+                    "resultFormat": "table"
+                }
+            ],
+            "title": "Log Analytics [AvailabilityRate_Query]",
+            "type": "timeseries"
+        }
+    ],
+    "refresh": "",
+    "revision": 1,
+    "schemaVersion": 38,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+        "list": [
             {
-              "targetBlank": true,
-              "title": "acr drill down details",
-              "url": "https://hotfix01-grafana-e0hudyfcbbbudgd7.eus.grafana.azure.com/d/mBHFSeX4z/containerregistry?orgId=1${__url_time_range}&var-selecteddate=${__data.fields.date}&${Region:queryparam}&${Subscriptions:queryparam}&${Solution:queryparam}"
-            }
-          ],
-          "mappings": [],
-          "max": 100,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 10,
-        "x": 10,
-        "y": 10
-      },
-      "id": 37,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "database": "hotfix01-metricsdb",
-          "datasource": {
-            "type": "grafana-azure-data-explorer-datasource",
-            "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-          },
-          "expression": {
-            "from": {
-              "property": {
-                "name": "Container_Registry_Availability",
-                "type": "string"
-              },
-              "type": "property"
+                "current": {
+                    "selected": true,
+                    "text": [
+                        "Solution 1"
+                    ],
+                    "value": [
+                        "Solution 1"
+                    ]
+                },
+                "datasource": {
+                    "type": "grafana-azure-data-explorer-datasource",
+                    "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                },
+                "definition": "Subscriptions\n| distinct solution",
+                "hide": 0,
+                "includeAll": false,
+                "multi": true,
+                "name": "Solution",
+                "options": [],
+                "query": "Subscriptions\n| distinct solution",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
             },
-            "groupBy": {
-              "expressions": [],
-              "type": "and"
-            },
-            "reduce": {
-              "expressions": [],
-              "type": "and"
-            },
-            "where": {
-              "expressions": [],
-              "type": "and"
-            }
-          },
-          "pluginVersion": "4.4.1",
-          "query": "Subscriptions\n|join Container_Registry_Availability on subscriptionId\n| where $__timeFilter(['date']) and isnotnull(successfulPullCount) and isnotnull(totalPullCount) and isnotnull(successfulPushCount) and isnotnull(totalPushCount)\n and location in ($Region) and subscriptionId in ($Subscriptions)\n and solution in ($Solution)\n| summarize acr = avg(((successfulPullCount+successfulPushCount)/(totalPullCount+totalPushCount))*100) by ['date']",
-          "querySource": "raw",
-          "queryType": "KQL",
-          "rawMode": true,
-          "refId": "A",
-          "resultFormat": "table"
-        }
-      ],
-      "title": "Container Registry Avg [((successfulPull+successfulPush)/(totalPullCount+totalPushCount))*100]",
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 17
-      },
-      "id": 8,
-      "panels": [],
-      "title": "Storage",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "grafana-azure-data-explorer-datasource",
-        "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-      },
-      "description": "Availability metric - https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftstoragestorageaccounts",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "decimals": 3,
-          "links": [
             {
-              "targetBlank": true,
-              "title": "storage drill down details",
-              "url": "https://hotfix01-grafana-e0hudyfcbbbudgd7.eus.grafana.azure.com/d/a6648f32-202e-4e7e-acea-7cbbb86c6877/storage?orgId=1${__url_time_range}&var-selecteddate=${__data.fields.date}&${Region:queryparam}&${Subscriptions:queryparam}&${Solution:queryparam}"
-            }
-          ],
-          "mappings": [],
-          "max": 100,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-red",
-                "value": null
-              },
-              {
-                "color": "dark-green",
-                "value": 100
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 10,
-        "x": 0,
-        "y": 18
-      },
-      "id": 25,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "database": "hotfix01-metricsdb",
-          "datasource": {
-            "type": "grafana-azure-data-explorer-datasource",
-            "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-          },
-          "expression": {
-            "from": {
-              "property": {
-                "name": "Storage_Availability",
-                "type": "string"
-              },
-              "type": "property"
+                "current": {
+                    "selected": true,
+                    "text": [
+                        " AG-CE-CI-TESTSUB-ONELHIRMEZ"
+                    ],
+                    "value": [
+                        "d6a99beb-93da-4c87-8e7a-2ad995aa1c94"
+                    ]
+                },
+                "datasource": {
+                    "type": "grafana-azure-data-explorer-datasource",
+                    "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                },
+                "definition": "Subscriptions\n| join Subscription_Names on subscriptionId\n| where solution in ($Solution)\n| extend valueAndText = strcat(subscriptionId, \"|\", name)\n| project valueAndText",
+                "hide": 0,
+                "includeAll": false,
+                "multi": true,
+                "name": "Subscriptions",
+                "options": [],
+                "query": "Subscriptions\n| join Subscription_Names on subscriptionId\n| where solution in ($Solution)\n| extend valueAndText = strcat(subscriptionId, \"|\", name)\n| project valueAndText",
+                "refresh": 1,
+                "regex": "(?<value>.*)\\|(?<text>.*)",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
             },
-            "groupBy": {
-              "expressions": [],
-              "type": "and"
-            },
-            "reduce": {
-              "expressions": [],
-              "type": "and"
-            },
-            "where": {
-              "expressions": [],
-              "type": "and"
-            }
-          },
-          "pluginVersion": "4.4.1",
-          "query": "Subscriptions\n|join Storage_Availability on subscriptionId\n| where $__timeFilter(['date']) and isnotnull(availability)\n and location in ($Region) and subscriptionId in ($Subscriptions)\n and solution in ($Solution)\n| summarize storage = (avg(availability)) by ['date']",
-          "querySource": "raw",
-          "queryType": "KQL",
-          "rawMode": true,
-          "refId": "A",
-          "resultFormat": "table"
-        }
-      ],
-      "title": "Storage Avg [Successful Tx / All Tx]",
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 25
-      },
-      "id": 10,
-      "panels": [],
-      "title": "Networking",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "grafana-azure-data-explorer-datasource",
-        "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-      },
-      "description": "Availability metric - https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftnetworkazurefirewalls",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "decimals": 3,
-          "links": [
             {
-              "targetBlank": true,
-              "title": "loadbalancer drill down details",
-              "url": "https://hotfix01-grafana-e0hudyfcbbbudgd7.eus.grafana.azure.com/d/ae2f6ffb-b5ff-403f-b7ee-1bd46c428595/loadbalancer?orgId=1${__url_time_range}&var-selecteddate=${__data.fields.date}&${Region:queryparam}&${Subscriptions:queryparam}&${Solution:queryparam}"
+                "current": {
+                    "selected": true,
+                    "text": [
+                        "eastus",
+                        "westus",
+                        "westus2",
+                        "eastus2",
+                        "northcentralus"
+                    ],
+                    "value": [
+                        "eastus",
+                        "westus",
+                        "westus2",
+                        "eastus2",
+                        "northcentralus"
+                    ]
+                },
+                "datasource": {
+                    "type": "grafana-azure-data-explorer-datasource",
+                    "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                },
+                "definition": "let region_1 = Aksservernode_Availability\n| distinct location;\nlet region_2 = Cosmosdb_Availability\n| distinct location;\nlet region_3 = Firewall_Availability\n| distinct location;\nlet region_4 = Keyvault_Availability\n| distinct location;\nlet region_5 = Loadbalancer_Availability\n| distinct location;\nlet region_6 = Storage_Availability\n| distinct location;\nlet region_7 = Cognitive_Svc_Availability\n| distinct location;\nlet region_8 = Container_Registry_Availability\n| distinct location;\nlet region_9 = Eventhubs_Availability\n| distinct location;\nunion region_1, region_2, region_3, region_4, region_5, region_6, region_7, region_8, region_9 | distinct *",
+                "hide": 0,
+                "includeAll": false,
+                "multi": true,
+                "name": "Region",
+                "options": [],
+                "query": "let region_1 = Aksservernode_Availability\n| distinct location;\nlet region_2 = Cosmosdb_Availability\n| distinct location;\nlet region_3 = Firewall_Availability\n| distinct location;\nlet region_4 = Keyvault_Availability\n| distinct location;\nlet region_5 = Loadbalancer_Availability\n| distinct location;\nlet region_6 = Storage_Availability\n| distinct location;\nlet region_7 = Cognitive_Svc_Availability\n| distinct location;\nlet region_8 = Container_Registry_Availability\n| distinct location;\nlet region_9 = Eventhubs_Availability\n| distinct location;\nunion region_1, region_2, region_3, region_4, region_5, region_6, region_7, region_8, region_9 | distinct *",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
             }
-          ],
-          "mappings": [],
-          "max": 100,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 10,
-        "x": 0,
-        "y": 26
-      },
-      "id": 31,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "database": "hotfix01-metricsdb",
-          "datasource": {
-            "type": "grafana-azure-data-explorer-datasource",
-            "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-          },
-          "expression": {
-            "from": {
-              "property": {
-                "name": "Loadbalancer_Availability",
-                "type": "string"
-              },
-              "type": "property"
-            },
-            "groupBy": {
-              "expressions": [],
-              "type": "and"
-            },
-            "reduce": {
-              "expressions": [],
-              "type": "and"
-            },
-            "where": {
-              "expressions": [],
-              "type": "and"
-            }
-          },
-          "pluginVersion": "4.5.0",
-          "query": "Subscriptions\n|join Loadbalancer_Availability on subscriptionId\n| where $__timeFilter(['date']) and isnotnull(availability)\n and location in ($Region) and subscriptionId in ($Subscriptions)\n and solution in ($Solution)\n| summarize loadbalancer = (avg(availability)) by ['date']",
-          "querySource": "raw",
-          "queryType": "KQL",
-          "rawMode": true,
-          "refId": "A",
-          "resultFormat": "table"
-        }
-      ],
-      "title": "Load Balancer Avg [Successful Tx / All Tx]",
-      "type": "timeseries"
+        ]
     },
-    {
-      "datasource": {
-        "type": "grafana-azure-data-explorer-datasource",
-        "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-      },
-      "description": "Availability metric -https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftnetworkazurefirewalls",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "decimals": 3,
-          "links": [
-            {
-              "targetBlank": true,
-              "title": "firewall drill down details",
-              "url": "https://hotfix01-grafana-e0hudyfcbbbudgd7.eus.grafana.azure.com/d/8HDuNUC4z/firewalls?orgId=1${__url_time_range}&var-selecteddate=${__data.fields.date}&${Region:queryparam}&${Subscriptions:queryparam}&${Solution:queryparam}"
-            }
-          ],
-          "mappings": [],
-          "max": 100,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 10,
-        "x": 10,
-        "y": 26
-      },
-      "id": 26,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "database": "hotfix01-metricsdb",
-          "datasource": {
-            "type": "grafana-azure-data-explorer-datasource",
-            "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-          },
-          "expression": {
-            "from": {
-              "property": {
-                "name": "Firewall_Availability",
-                "type": "string"
-              },
-              "type": "property"
-            },
-            "groupBy": {
-              "expressions": [],
-              "type": "and"
-            },
-            "reduce": {
-              "expressions": [],
-              "type": "and"
-            },
-            "where": {
-              "expressions": [],
-              "type": "and"
-            }
-          },
-          "pluginVersion": "4.5.0",
-          "query": "Subscriptions\n|join Firewall_Availability on subscriptionId\n| where $__timeFilter(['date']) and isnotnull(availability)\n and location in ($Region) and subscriptionId in ($Subscriptions)\n and solution in ($Solution)\n| summarize firewall = (avg(availability)) by ['date']",
-          "querySource": "raw",
-          "queryType": "KQL",
-          "rawMode": true,
-          "refId": "A",
-          "resultFormat": "table"
-        }
-      ],
-      "title": "Firewall Avg [Successful Tx / All Tx]",
-      "type": "timeseries"
+    "time": {
+        "from": "now-7d",
+        "to": "now"
     },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 33
-      },
-      "id": 12,
-      "panels": [],
-      "title": "Databases",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "grafana-azure-data-explorer-datasource",
-        "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-      },
-      "description": "availability metric - https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftdocumentdbdatabaseaccounts",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "decimals": 3,
-          "links": [
-            {
-              "targetBlank": true,
-              "title": "cosmosdb drill down details",
-              "url": "https://hotfix01-grafana-e0hudyfcbbbudgd7.eus.grafana.azure.com/d/c2f79638-95d3-4c63-9492-af49531e7f23/cosmosdb-details?orgId=1${__url_time_range}&var-selecteddate=${__data.fields.date}&${Region:queryparam}&${Subscriptions:queryparam}&${Solution:queryparam}"
-            }
-          ],
-          "mappings": [],
-          "max": 100,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 10,
-        "x": 0,
-        "y": 34
-      },
-      "id": 28,
-      "links": [],
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "database": "hotfix01-metricsdb",
-          "datasource": {
-            "type": "grafana-azure-data-explorer-datasource",
-            "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-          },
-          "expression": {
-            "from": {
-              "property": {
-                "name": "Cosmosdb_Availability",
-                "type": "string"
-              },
-              "type": "property"
-            },
-            "groupBy": {
-              "expressions": [],
-              "type": "and"
-            },
-            "reduce": {
-              "expressions": [],
-              "type": "and"
-            },
-            "where": {
-              "expressions": [],
-              "type": "and"
-            }
-          },
-          "pluginVersion": "4.5.0",
-          "query": "Subscriptions\n|join Cosmosdb_Availability on subscriptionId\n| where $__timeFilter(['date']) and isnotnull(availability)\n and location in ($Region) and subscriptionId in ($Subscriptions)\n and solution in ($Solution)\n| summarize cosmosdb = (avg(availability)) by ['date']",
-          "querySource": "raw",
-          "queryType": "KQL",
-          "rawMode": true,
-          "refId": "A",
-          "resultFormat": "table"
-        }
-      ],
-      "title": "Cosmos DB Avg [Successful Tx / All Tx]",
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 41
-      },
-      "id": 14,
-      "panels": [],
-      "title": "Identity + Security",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "grafana-azure-data-explorer-datasource",
-        "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-      },
-      "description": "availability metric - https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftdocumentdbdatabaseaccounts",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "decimals": 3,
-          "links": [
-            {
-              "targetBlank": true,
-              "title": "keyvault drill down details",
-              "url": "https://hotfix01-grafana-e0hudyfcbbbudgd7.eus.grafana.azure.com/d/f44a3ad2-41db-45c9-93db-10d33cf87231/keyvault?orgId=1${__url_time_range}&var-selecteddate=${__data.fields.date}&${Region:queryparam}&${Subscriptions:queryparam}&${Solution:queryparam}"
-            }
-          ],
-          "mappings": [],
-          "max": 100,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 10,
-        "x": 0,
-        "y": 42
-      },
-      "id": 27,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "database": "hotfix01-metricsdb",
-          "datasource": {
-            "type": "grafana-azure-data-explorer-datasource",
-            "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-          },
-          "expression": {
-            "from": {
-              "property": {
-                "name": "Keyvault_Availability",
-                "type": "string"
-              },
-              "type": "property"
-            },
-            "groupBy": {
-              "expressions": [],
-              "type": "and"
-            },
-            "reduce": {
-              "expressions": [],
-              "type": "and"
-            },
-            "where": {
-              "expressions": [],
-              "type": "and"
-            }
-          },
-          "pluginVersion": "4.5.0",
-          "query": "Subscriptions\n|join Keyvault_Availability on subscriptionId\n| where $__timeFilter(['date']) and isnotnull(availability)\n and location in ($Region) and subscriptionId in ($Subscriptions)\n and solution in ($Solution)\n| summarize keyvault = (avg(availability)) by ['date']",
-          "querySource": "raw",
-          "queryType": "KQL",
-          "rawMode": true,
-          "refId": "A",
-          "resultFormat": "table"
-        }
-      ],
-      "title": "Key Vault Avg [Successful Tx / All Tx]",
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 49
-      },
-      "id": 33,
-      "panels": [],
-      "title": "AI + Machine Learning",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "grafana-azure-data-explorer-datasource",
-        "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-      },
-      "description": "Availability metric - https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftcognitiveservicesaccounts",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "decimals": 3,
-          "links": [
-            {
-              "targetBlank": true,
-              "title": "cognitive service drill down details",
-              "url": "https://hotfix01-grafana-e0hudyfcbbbudgd7.eus.grafana.azure.com/d/lyldI6u4z/cognitiveservices?orgId=1${__url_time_range}&var-selecteddate=${__data.fields.date}&${Region:queryparam}&${Subscriptions:queryparam}&${Solution:queryparam}"
-            }
-          ],
-          "mappings": [],
-          "max": 100,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 10,
-        "x": 0,
-        "y": 50
-      },
-      "id": 35,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "database": "hotfix01-metricsdb",
-          "datasource": {
-            "type": "grafana-azure-data-explorer-datasource",
-            "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-          },
-          "expression": {
-            "from": {
-              "property": {
-                "name": "Aksservernode_Availability_Raw",
-                "type": "string"
-              },
-              "type": "property"
-            },
-            "groupBy": {
-              "expressions": [],
-              "type": "and"
-            },
-            "reduce": {
-              "expressions": [],
-              "type": "and"
-            },
-            "where": {
-              "expressions": [],
-              "type": "and"
-            }
-          },
-          "pluginVersion": "4.4.1",
-          "query": "Subscriptions\r\n|join Cognitive_Svc_Availability on subscriptionId\r\n| where $__timeFilter(['date']) and isnotnull(availability)\r\n and location in ($Region) and subscriptionId in ($Subscriptions)\r\n and solution in ($Solution)\r\n| summarize csa = (avg(availability)) by ['date']",
-          "querySource": "raw",
-          "queryType": "KQL",
-          "rawMode": true,
-          "refId": "A",
-          "resultFormat": "table"
-        }
-      ],
-      "title": "Cognitive Services [Successful Tx / All Tx]",
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 57
-      },
-      "id": 39,
-      "panels": [],
-      "title": "Analytics",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "grafana-azure-data-explorer-datasource",
-        "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-      },
-      "description": "Availability metric - https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsofteventhubnamespaces",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "decimals": 3,
-          "links": [
-            {
-              "targetBlank": true,
-              "title": "eventhubs drill down details",
-              "url": "https://hotfix01-grafana-e0hudyfcbbbudgd7.eus.grafana.azure.com/d/K9cdIeu4z/eventhubs?orgId=1${__url_time_range}&var-selecteddate=${__data.fields.date}&${Region:queryparam}&${Subscriptions:queryparam}&${Solution:queryparam}"
-            }
-          ],
-          "mappings": [],
-          "max": 100,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 10,
-        "x": 0,
-        "y": 58
-      },
-      "id": 41,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "database": "hotfix01-metricsdb",
-          "datasource": {
-            "type": "grafana-azure-data-explorer-datasource",
-            "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-          },
-          "expression": {
-            "from": {
-              "property": {
-                "name": "Aksservernode_Availability_Raw",
-                "type": "string"
-              },
-              "type": "property"
-            },
-            "groupBy": {
-              "expressions": [],
-              "type": "and"
-            },
-            "reduce": {
-              "expressions": [],
-              "type": "and"
-            },
-            "where": {
-              "expressions": [],
-              "type": "and"
-            }
-          },
-          "pluginVersion": "4.4.1",
-          "query": "Subscriptions\r\n|join Eventhubs_Availability on subscriptionId\r\n| where $__timeFilter(['date']) and isnotnull(incomingRequests) and isnotnull(serverErrors)\r\n and location in ($Region) and subscriptionId in ($Subscriptions)\r\n and solution in ($Solution)\r\n| summarize eventhubs = avg((incomingRequests-serverErrors)/incomingRequests)*100 by ['date']",
-          "querySource": "raw",
-          "queryType": "KQL",
-          "rawMode": true,
-          "refId": "A",
-          "resultFormat": "table"
-        }
-      ],
-      "title": "Eventhubs [(incomingRequests-serverErrors)/incomingRequests)*100]",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "grafana-azure-data-explorer-datasource",
-        "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-      },
-      "description": "Availability metric - https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftoperationalinsightsworkspaces",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "decimals": 3,
-          "links": [
-            {
-              "targetBlank": true,
-              "title": "loganalytics drill down details",
-              "url": "https://hotfix01-grafana-e0hudyfcbbbudgd7.eus.grafana.azure.com/d/mpNZfMr4k/loganalytics?orgId=1${__url_time_range}&var-selecteddate=${__data.fields.date}&${Region:queryparam}&${Subscriptions:queryparam}&${Solution:queryparam}"
-            }
-          ],
-          "mappings": [],
-          "max": 100,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 10,
-        "x": 10,
-        "y": 58
-      },
-      "id": 46,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "database": "hotfix01-metricsdb",
-          "datasource": {
-            "type": "grafana-azure-data-explorer-datasource",
-            "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-          },
-          "expression": {
-            "from": {
-              "property": {
-                "name": "Aksservernode_Availability_Raw",
-                "type": "string"
-              },
-              "type": "property"
-            },
-            "groupBy": {
-              "expressions": [],
-              "type": "and"
-            },
-            "reduce": {
-              "expressions": [],
-              "type": "and"
-            },
-            "where": {
-              "expressions": [],
-              "type": "and"
-            }
-          },
-          "pluginVersion": "4.4.1",
-          "query": "Subscriptions\r\n|join LogAnalytics_Availability on subscriptionId\r\n| where $__timeFilter(['date']) and isnotnull(availability)\r\n and location in ($Region) and subscriptionId in ($Subscriptions)\r\n and solution in ($Solution)\r\n| summarize loganalytics = avg(availability) by ['date']",
-          "querySource": "raw",
-          "queryType": "KQL",
-          "rawMode": true,
-          "refId": "A",
-          "resultFormat": "table"
-        }
-      ],
-      "title": "Log Analytics [AvailabilityRate_Query]",
-      "type": "timeseries"
-    }
-  ],
-  "refresh": "",
-  "revision": 1,
-  "schemaVersion": 38,
-  "style": "dark",
-  "tags": [],
-  "templating": {
-    "list": [
-      {
-        "current": {
-          "selected": false,
-          "text": [
-            "Solution 1",
-            "Solution 3",
-            "Solution 4"
-          ],
-          "value": [
-            "Solution 1",
-            "Solution 3",
-            "Solution 4"
-          ]
-        },
-        "datasource": {
-          "type": "grafana-azure-data-explorer-datasource",
-          "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-        },
-        "definition": "Subscriptions\n| distinct solution",
-        "hide": 0,
-        "includeAll": false,
-        "multi": true,
-        "name": "Solution",
-        "options": [],
-        "query": "Subscriptions\n| distinct solution",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "current": {
-          "selected": false,
-          "text": [
-            " AG_CI_CE_BLK_CORE_ANITRA",
-            " AG-CE-CI-TESTSUB-ONELHIRMEZ",
-            " AG-CE-CI-TESTSUB-DIVYABHU"
-          ],
-          "value": [
-            "0302e263-20e2-44ea-9d57-91db52a566fe",
-            "d6a99beb-93da-4c87-8e7a-2ad995aa1c94",
-            "7d528e8d-eb2d-4ebb-9aab-2d9d2f3a466a"
-          ]
-        },
-        "datasource": {
-          "type": "grafana-azure-data-explorer-datasource",
-          "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-        },
-        "definition": "Subscriptions\n| join Subscription_Names on subscriptionId\n| where solution in ($Solution)\n| extend valueAndText = strcat(subscriptionId, \"|\", name)\n| project valueAndText",
-        "hide": 0,
-        "includeAll": false,
-        "multi": true,
-        "name": "Subscriptions",
-        "options": [],
-        "query": "Subscriptions\n| join Subscription_Names on subscriptionId\n| where solution in ($Solution)\n| extend valueAndText = strcat(subscriptionId, \"|\", name)\n| project valueAndText",
-        "refresh": 1,
-        "regex": "(?<value>.*)\\|(?<text>.*)",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "current": {
-          "selected": false,
-          "text": [
-            "westus",
-            "westus3",
-            "eastus",
-            "westus2",
-            "eastus2",
-            "northcentralus",
-            "centralus"
-          ],
-          "value": [
-            "westus",
-            "westus3",
-            "eastus",
-            "westus2",
-            "eastus2",
-            "northcentralus",
-            "centralus"
-          ]
-        },
-        "datasource": {
-          "type": "grafana-azure-data-explorer-datasource",
-          "uid": "e1ba3759-653a-4c7d-bb20-857dd9dd8880"
-        },
-        "definition": "let region_1 = Aksservernode_Availability\n| distinct location;\nlet region_2 = Cosmosdb_Availability\n| distinct location;\nlet region_3 = Firewall_Availability\n| distinct location;\nlet region_4 = Keyvault_Availability\n| distinct location;\nlet region_5 = Loadbalancer_Availability\n| distinct location;\nlet region_6 = Storage_Availability\n| distinct location;\nlet region_7 = Cognitive_Svc_Availability\n| distinct location;\nlet region_8 = Container_Registry_Availability\n| distinct location;\nlet region_9 = Eventhubs_Availability\n| distinct location;\nunion region_1, region_2, region_3, region_4, region_5, region_6, region_7, region_8, region_9 | distinct *",
-        "hide": 0,
-        "includeAll": false,
-        "multi": true,
-        "name": "Region",
-        "options": [],
-        "query": "let region_1 = Aksservernode_Availability\n| distinct location;\nlet region_2 = Cosmosdb_Availability\n| distinct location;\nlet region_3 = Firewall_Availability\n| distinct location;\nlet region_4 = Keyvault_Availability\n| distinct location;\nlet region_5 = Loadbalancer_Availability\n| distinct location;\nlet region_6 = Storage_Availability\n| distinct location;\nlet region_7 = Cognitive_Svc_Availability\n| distinct location;\nlet region_8 = Container_Registry_Availability\n| distinct location;\nlet region_9 = Eventhubs_Availability\n| distinct location;\nunion region_1, region_2, region_3, region_4, region_5, region_6, region_7, region_8, region_9 | distinct *",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      }
-    ]
-  },
-  "time": {
-    "from": "now-7d",
-    "to": "now"
-  },
-  "timepicker": {},
-  "timezone": "utc",
-  "title": "Azure Observability Dashboard",
-  "uid": "VVUlnjx4z",
-  "version": 5,
-  "weekStart": ""
+    "timepicker": {},
+    "timezone": "utc",
+    "title": "Azure Observability Dashboard",
+    "uid": "VVUlnjx4z",
+    "version": 2,
+    "weekStart": ""
 }

--- a/Utils/scripts/dashboard_templates/CognitiveServices-1687851601199.json
+++ b/Utils/scripts/dashboard_templates/CognitiveServices-1687851601199.json
@@ -1,238 +1,257 @@
 {
-  "annotations": {
-    "list": [
-      {
-        "builtIn": 1,
-        "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
-        },
-        "enable": true,
-        "hide": true,
-        "iconColor": "rgba(0, 211, 255, 1)",
-        "name": "Annotations & Alerts",
-        "target": {
-          "limit": 100,
-          "matchAny": false,
-          "tags": [],
-          "type": "dashboard"
-        },
-        "type": "dashboard"
-      }
-    ]
-  },
-  "editable": true,
-  "fiscalYearStartMonth": 0,
-  "graphTooltip": 0,
-  "id": 37,
-  "links": [],
-  "liveNow": false,
-  "panels": [
-    {
-      "datasource": {
-        "type": "grafana-azure-data-explorer-datasource",
-        "uid": "uRhkgPj4k"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "color-text"
-            },
-            "filterable": true,
-            "inspect": true
-          },
-          "decimals": 3,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-red",
-                "value": null
-              },
-              {
-                "color": "dark-green",
-                "value": 100
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 12,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 2,
-      "options": {
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": true
-      },
-      "pluginVersion": "9.4.12",
-      "targets": [
-        {
-          "database": "func04-metricsdb",
-          "datasource": {
-            "type": "grafana-azure-data-explorer-datasource",
-            "uid": "uRhkgPj4k"
-          },
-          "expression": {
-            "from": {
-              "property": {
-                "name": "Vm_Availability",
-                "type": "string"
-              },
-              "type": "property"
-            },
-            "groupBy": {
-              "expressions": [],
-              "type": "and"
-            },
-            "reduce": {
-              "expressions": [],
-              "type": "and"
-            },
-            "where": {
-              "expressions": [],
-              "type": "and"
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": {
+                    "type": "grafana",
+                    "uid": "-- Grafana --"
+                },
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "target": {
+                    "limit": 100,
+                    "matchAny": false,
+                    "tags": [],
+                    "type": "dashboard"
+                },
+                "type": "dashboard"
             }
-          },
-          "pluginVersion": "4.4.1",
-          "query": "Cognitive_Svc_Availability\n| where  ['date']  == datetime($selecteddate) and isnotnull(availability)\nand location in ($Region) and subscriptionId in ($Subscriptions) and availability < 100\n| project ['date'] , subscriptionId, id, location, name, availability\n| order by availability asc \n| order by ['date'] asc",
-          "querySource": "raw",
-          "queryType": "KQL",
-          "rawMode": true,
-          "refId": "A",
-          "resultFormat": "table"
+        ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 38,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+        {
+            "datasource": {
+                "type": "grafana-azure-data-explorer-datasource",
+                "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "align": "auto",
+                        "cellOptions": {
+                            "type": "color-text"
+                        },
+                        "filterable": true,
+                        "inspect": true
+                    },
+                    "decimals": 3,
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "dark-red",
+                                "value": null
+                            },
+                            {
+                                "color": "dark-green",
+                                "value": 100
+                            }
+                        ]
+                    }
+                },
+                "overrides": [
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "id"
+                        },
+                        "properties": [
+                            {
+                                "id": "links",
+                                "value": [
+                                    {
+                                        "targetBlank": true,
+                                        "title": "",
+                                        "url": "https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource${__value.raw}/overview"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            "gridPos": {
+                "h": 12,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 2,
+            "options": {
+                "cellHeight": "sm",
+                "footer": {
+                    "countRows": false,
+                    "fields": "",
+                    "reducer": [
+                        "sum"
+                    ],
+                    "show": false
+                },
+                "showHeader": true
+            },
+            "pluginVersion": "9.5.6",
+            "targets": [
+                {
+                    "database": "sk001-metricsdb",
+                    "datasource": {
+                        "type": "grafana-azure-data-explorer-datasource",
+                        "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                    },
+                    "expression": {
+                        "from": {
+                            "property": {
+                                "name": "Vm_Availability",
+                                "type": "string"
+                            },
+                            "type": "property"
+                        },
+                        "groupBy": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "reduce": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "where": {
+                            "expressions": [],
+                            "type": "and"
+                        }
+                    },
+                    "pluginVersion": "4.4.1",
+                    "query": "Cognitive_Svc_Availability\n| where  ['date']  == datetime($selecteddate) and isnotnull(availability)\nand location in ($Region) and subscriptionId in ($Subscriptions) and availability < 100\n| project ['date'] , subscriptionId, id, location, name, availability\n| order by availability asc \n| order by ['date'] asc",
+                    "querySource": "raw",
+                    "queryType": "KQL",
+                    "rawMode": true,
+                    "refId": "A",
+                    "resultFormat": "table"
+                }
+            ],
+            "title": "# of CognitiveServices with Availability < 100",
+            "type": "table"
         }
-      ],
-      "title": "# of CognitiveServices with Availability < 100",
-      "type": "table"
-    }
-  ],
-  "refresh": "",
-  "revision": 1,
-  "schemaVersion": 38,
-  "style": "dark",
-  "tags": [],
-  "templating": {
-    "list": [
-      {
-        "current": {
-          "selected": false,
-          "text": "2023-01-12 00:00:00",
-          "value": "2023-01-12 00:00:00"
-        },
-        "hide": 2,
-        "name": "selecteddate",
-        "options": [
-          {
-            "selected": true,
-            "text": "2023-01-12 00:00:00",
-            "value": "2023-01-12 00:00:00"
-          }
-        ],
-        "query": "2023-01-12 00:00:00",
-        "skipUrlSync": false,
-        "type": "textbox",
-        "datasource": null
-      },
-      {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
-        "datasource": {
-          "type": "grafana-azure-data-explorer-datasource",
-          "uid": "uRhkgPj4k"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": true,
-        "name": "Region",
-        "options": [],
-        "query": "",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
-        "datasource": {
-          "type": "grafana-azure-data-explorer-datasource",
-          "uid": "uRhkgPj4k"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": true,
-        "name": "Subscriptions",
-        "options": [],
-        "query": "",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
-        "datasource": {
-          "type": "grafana-azure-data-explorer-datasource",
-          "uid": "uRhkgPj4k"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": true,
-        "name": "Solution",
-        "options": [],
-        "query": "",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      }
-    ]
-  },
-  "time": {
-    "from": "now-6h",
-    "to": "now"
-  },
-  "timepicker": {},
-  "timezone": "utc",
-  "title": "CognitiveServices",
-  "uid": "lyldI6u4z",
-  "version": 3,
-  "weekStart": ""
+    ],
+    "refresh": "",
+    "revision": 1,
+    "schemaVersion": 38,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+        "list": [
+            {
+                "current": {
+                    "selected": false,
+                    "text": "2023-01-12 00:00:00",
+                    "value": "2023-01-12 00:00:00"
+                },
+                "hide": 2,
+                "name": "selecteddate",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "2023-01-12 00:00:00",
+                        "value": "2023-01-12 00:00:00"
+                    }
+                ],
+                "query": "2023-01-12 00:00:00",
+                "skipUrlSync": false,
+                "type": "textbox"
+            },
+            {
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": {
+                    "type": "grafana-azure-data-explorer-datasource",
+                    "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                },
+                "definition": "",
+                "hide": 2,
+                "includeAll": false,
+                "multi": true,
+                "name": "Region",
+                "options": [],
+                "query": "",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
+            },
+            {
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": {
+                    "type": "grafana-azure-data-explorer-datasource",
+                    "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                },
+                "definition": "",
+                "hide": 2,
+                "includeAll": false,
+                "multi": true,
+                "name": "Subscriptions",
+                "options": [],
+                "query": "",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
+            },
+            {
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": {
+                    "type": "grafana-azure-data-explorer-datasource",
+                    "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                },
+                "definition": "",
+                "hide": 2,
+                "includeAll": false,
+                "multi": true,
+                "name": "Solution",
+                "options": [],
+                "query": "",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-6h",
+        "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "utc",
+    "title": "CognitiveServices",
+    "uid": "lyldI6u4z",
+    "version": 2,
+    "weekStart": ""
 }

--- a/Utils/scripts/dashboard_templates/ContainerRegistry-1687851648145.json
+++ b/Utils/scripts/dashboard_templates/ContainerRegistry-1687851648145.json
@@ -1,238 +1,257 @@
 {
-  "annotations": {
-    "list": [
-      {
-        "builtIn": 1,
-        "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
-        },
-        "enable": true,
-        "hide": true,
-        "iconColor": "rgba(0, 211, 255, 1)",
-        "name": "Annotations & Alerts",
-        "target": {
-          "limit": 100,
-          "matchAny": false,
-          "tags": [],
-          "type": "dashboard"
-        },
-        "type": "dashboard"
-      }
-    ]
-  },
-  "editable": true,
-  "fiscalYearStartMonth": 0,
-  "graphTooltip": 0,
-  "id": 38,
-  "links": [],
-  "liveNow": false,
-  "panels": [
-    {
-      "datasource": {
-        "type": "grafana-azure-data-explorer-datasource",
-        "uid": "uRhkgPj4k"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "color-text"
-            },
-            "filterable": true,
-            "inspect": true
-          },
-          "decimals": 3,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-red",
-                "value": null
-              },
-              {
-                "color": "dark-green",
-                "value": 100
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 12,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 2,
-      "options": {
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": true
-      },
-      "pluginVersion": "9.4.12",
-      "targets": [
-        {
-          "database": "func04-metricsdb",
-          "datasource": {
-            "type": "grafana-azure-data-explorer-datasource",
-            "uid": "uRhkgPj4k"
-          },
-          "expression": {
-            "from": {
-              "property": {
-                "name": "Vm_Availability",
-                "type": "string"
-              },
-              "type": "property"
-            },
-            "groupBy": {
-              "expressions": [],
-              "type": "and"
-            },
-            "reduce": {
-              "expressions": [],
-              "type": "and"
-            },
-            "where": {
-              "expressions": [],
-              "type": "and"
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": {
+                    "type": "grafana",
+                    "uid": "-- Grafana --"
+                },
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "target": {
+                    "limit": 100,
+                    "matchAny": false,
+                    "tags": [],
+                    "type": "dashboard"
+                },
+                "type": "dashboard"
             }
-          },
-          "pluginVersion": "4.4.1",
-          "query": "Subscriptions\n|join Container_Registry_Availability on subscriptionId\n| project component, createdAt, ['date'], id, location, name, successfulPullCount, totalPullCount,\nsolution, subscriptionId,tenancy, availability = ((successfulPullCount+successfulPushCount)/(totalPullCount+totalPushCount))*100\n| where ['date']  == datetime($selecteddate)\n and location in ($Region) and subscriptionId in ($Subscriptions)\n and solution in ($Solution) and availability < 100\n| project ['date'] , subscriptionId, id, location, name, availability\n| order by availability asc \n| order by ['date'] asc",
-          "querySource": "raw",
-          "queryType": "KQL",
-          "rawMode": true,
-          "refId": "A",
-          "resultFormat": "table"
+        ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 34,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+        {
+            "datasource": {
+                "type": "grafana-azure-data-explorer-datasource",
+                "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "align": "auto",
+                        "cellOptions": {
+                            "type": "color-text"
+                        },
+                        "filterable": true,
+                        "inspect": true
+                    },
+                    "decimals": 3,
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "dark-red",
+                                "value": null
+                            },
+                            {
+                                "color": "dark-green",
+                                "value": 100
+                            }
+                        ]
+                    }
+                },
+                "overrides": [
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "id"
+                        },
+                        "properties": [
+                            {
+                                "id": "links",
+                                "value": [
+                                    {
+                                        "targetBlank": true,
+                                        "title": "",
+                                        "url": "https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource${__value.raw}/overview"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            "gridPos": {
+                "h": 12,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 2,
+            "options": {
+                "cellHeight": "sm",
+                "footer": {
+                    "countRows": false,
+                    "fields": "",
+                    "reducer": [
+                        "sum"
+                    ],
+                    "show": false
+                },
+                "showHeader": true
+            },
+            "pluginVersion": "9.5.6",
+            "targets": [
+                {
+                    "database": "sk001-metricsdb",
+                    "datasource": {
+                        "type": "grafana-azure-data-explorer-datasource",
+                        "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                    },
+                    "expression": {
+                        "from": {
+                            "property": {
+                                "name": "Vm_Availability",
+                                "type": "string"
+                            },
+                            "type": "property"
+                        },
+                        "groupBy": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "reduce": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "where": {
+                            "expressions": [],
+                            "type": "and"
+                        }
+                    },
+                    "pluginVersion": "4.4.1",
+                    "query": "Subscriptions\n|join Container_Registry_Availability on subscriptionId\n| project component, createdAt, ['date'], id, location, name, successfulPullCount, totalPullCount,\nsolution, subscriptionId,tenancy, availability = ((successfulPullCount+successfulPushCount)/(totalPullCount+totalPushCount))*100\n| where ['date']  == datetime($selecteddate)\n and location in ($Region) and subscriptionId in ($Subscriptions)\n and solution in ($Solution) and availability < 100\n| project ['date'] , subscriptionId, id, location, name, availability\n| order by availability asc \n| order by ['date'] asc",
+                    "querySource": "raw",
+                    "queryType": "KQL",
+                    "rawMode": true,
+                    "refId": "A",
+                    "resultFormat": "table"
+                }
+            ],
+            "title": "# of ContainerRegistries with Availability < 100",
+            "type": "table"
         }
-      ],
-      "title": "# of ContainerRegistries with Availability < 100",
-      "type": "table"
-    }
-  ],
-  "refresh": "",
-  "revision": 1,
-  "schemaVersion": 38,
-  "style": "dark",
-  "tags": [],
-  "templating": {
-    "list": [
-      {
-        "current": {
-          "selected": false,
-          "text": "2023-01-12 00:00:00",
-          "value": "2023-01-12 00:00:00"
-        },
-        "hide": 2,
-        "name": "selecteddate",
-        "options": [
-          {
-            "selected": true,
-            "text": "2023-01-12 00:00:00",
-            "value": "2023-01-12 00:00:00"
-          }
-        ],
-        "query": "2023-01-12 00:00:00",
-        "skipUrlSync": false,
-        "type": "textbox",
-        "datasource": null
-      },
-      {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
-        "datasource": {
-          "type": "grafana-azure-data-explorer-datasource",
-          "uid": "uRhkgPj4k"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": true,
-        "name": "Region",
-        "options": [],
-        "query": "",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
-        "datasource": {
-          "type": "grafana-azure-data-explorer-datasource",
-          "uid": "uRhkgPj4k"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": true,
-        "name": "Subscriptions",
-        "options": [],
-        "query": "",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
-        "datasource": {
-          "type": "grafana-azure-data-explorer-datasource",
-          "uid": "uRhkgPj4k"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": true,
-        "name": "Solution",
-        "options": [],
-        "query": "",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      }
-    ]
-  },
-  "time": {
-    "from": "now-6h",
-    "to": "now"
-  },
-  "timepicker": {},
-  "timezone": "utc",
-  "title": "ContainerRegistry",
-  "uid": "mBHFSeX4z",
-  "version": 3,
-  "weekStart": ""
+    ],
+    "refresh": "",
+    "revision": 1,
+    "schemaVersion": 38,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+        "list": [
+            {
+                "current": {
+                    "selected": false,
+                    "text": "2023-01-12 00:00:00",
+                    "value": "2023-01-12 00:00:00"
+                },
+                "hide": 2,
+                "name": "selecteddate",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "2023-01-12 00:00:00",
+                        "value": "2023-01-12 00:00:00"
+                    }
+                ],
+                "query": "2023-01-12 00:00:00",
+                "skipUrlSync": false,
+                "type": "textbox"
+            },
+            {
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": {
+                    "type": "grafana-azure-data-explorer-datasource",
+                    "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                },
+                "definition": "",
+                "hide": 2,
+                "includeAll": false,
+                "multi": true,
+                "name": "Region",
+                "options": [],
+                "query": "",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
+            },
+            {
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": {
+                    "type": "grafana-azure-data-explorer-datasource",
+                    "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                },
+                "definition": "",
+                "hide": 2,
+                "includeAll": false,
+                "multi": true,
+                "name": "Subscriptions",
+                "options": [],
+                "query": "",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
+            },
+            {
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": {
+                    "type": "grafana-azure-data-explorer-datasource",
+                    "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                },
+                "definition": "",
+                "hide": 2,
+                "includeAll": false,
+                "multi": true,
+                "name": "Solution",
+                "options": [],
+                "query": "",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-6h",
+        "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "utc",
+    "title": "ContainerRegistry",
+    "uid": "mBHFSeX4z",
+    "version": 4,
+    "weekStart": ""
 }

--- a/Utils/scripts/dashboard_templates/CosmosDB-1679088907885.json
+++ b/Utils/scripts/dashboard_templates/CosmosDB-1679088907885.json
@@ -1,246 +1,270 @@
 {
-  "annotations": {
-    "list": [
-      {
-        "builtIn": 1,
-        "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
-        },
-        "enable": true,
-        "hide": true,
-        "iconColor": "rgba(0, 211, 255, 1)",
-        "name": "Annotations & Alerts",
-        "target": {
-          "limit": 100,
-          "matchAny": false,
-          "tags": [],
-          "type": "dashboard"
-        },
-        "type": "dashboard"
-      }
-    ]
-  },
-  "editable": true,
-  "fiscalYearStartMonth": 0,
-  "graphTooltip": 0,
-  "id": 26,
-  "links": [],
-  "liveNow": false,
-  "panels": [
-    {
-      "datasource": {
-        "type": "grafana-azure-data-explorer-datasource",
-        "uid": "uRhkgPj4k"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "align": "auto",
-            "displayMode": "color-text",
-            "filterable": true,
-            "inspect": true
-          },
-          "decimals": 3,
-          "mappings": [],
-          "thresholds": {
-            "mode": "percentage",
-            "steps": [
-              {
-                "color": "semi-dark-red",
-                "value": null
-              },
-              {
-                "color": "dark-green",
-                "value": 100
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "availability"
-            },
-            "properties": [
-              {
-                "id": "custom.displayMode",
-                "value": "color-text"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 12,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 2,
-      "options": {
-        "footer": {
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": true
-      },
-      "pluginVersion": "9.3.8",
-      "targets": [
-        {
-          "database": "func04-metricsdb",
-          "datasource": {
-            "type": "grafana-azure-data-explorer-datasource",
-            "uid": "uRhkgPj4k"
-          },
-          "expression": {
-            "from": {
-              "property": {
-                "name": "vm_availability",
-                "type": "string"
-              },
-              "type": "property"
-            },
-            "groupBy": {
-              "expressions": [],
-              "type": "and"
-            },
-            "reduce": {
-              "expressions": [],
-              "type": "and"
-            },
-            "where": {
-              "expressions": [],
-              "type": "and"
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": {
+                    "type": "grafana",
+                    "uid": "-- Grafana --"
+                },
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "target": {
+                    "limit": 100,
+                    "matchAny": false,
+                    "tags": [],
+                    "type": "dashboard"
+                },
+                "type": "dashboard"
             }
-          },
-          "pluginVersion": "4.2.0",
-          "query": "Cosmosdb_Availability\n| where  ['date']  == datetime($selecteddate) and isnotnull(availability)\nand location in ($Region) and subscriptionId in ($Subscriptions) and availability < 100\n| project ['date'] , subscriptionId, id, location, name, availability\n| order by availability asc \n| order by ['date'] asc",
-          "querySource": "raw",
-          "rawMode": true,
-          "refId": "A",
-          "resultFormat": "table"
+        ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 36,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+        {
+            "datasource": {
+                "type": "grafana-azure-data-explorer-datasource",
+                "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "align": "auto",
+                        "cellOptions": {
+                            "type": "color-text"
+                        },
+                        "filterable": true,
+                        "inspect": true
+                    },
+                    "decimals": 3,
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "percentage",
+                        "steps": [
+                            {
+                                "color": "semi-dark-red",
+                                "value": null
+                            },
+                            {
+                                "color": "dark-green",
+                                "value": 100
+                            }
+                        ]
+                    }
+                },
+                "overrides": [
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "availability"
+                        },
+                        "properties": [
+                            {
+                                "id": "custom.cellOptions",
+                                "value": {
+                                    "type": "color-text"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "id"
+                        },
+                        "properties": [
+                            {
+                                "id": "links",
+                                "value": [
+                                    {
+                                        "targetBlank": true,
+                                        "title": "",
+                                        "url": "https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource${__value.raw}/overview"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            "gridPos": {
+                "h": 12,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 2,
+            "options": {
+                "cellHeight": "sm",
+                "footer": {
+                    "countRows": false,
+                    "fields": "",
+                    "reducer": [
+                        "sum"
+                    ],
+                    "show": false
+                },
+                "showHeader": true
+            },
+            "pluginVersion": "9.5.6",
+            "targets": [
+                {
+                    "database": "sk001-metricsdb",
+                    "datasource": {
+                        "type": "grafana-azure-data-explorer-datasource",
+                        "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                    },
+                    "expression": {
+                        "from": {
+                            "property": {
+                                "name": "vm_availability",
+                                "type": "string"
+                            },
+                            "type": "property"
+                        },
+                        "groupBy": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "reduce": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "where": {
+                            "expressions": [],
+                            "type": "and"
+                        }
+                    },
+                    "pluginVersion": "4.5.0",
+                    "query": "Cosmosdb_Availability\n| where  ['date']  == datetime($selecteddate) and isnotnull(availability)\nand location in ($Region) and subscriptionId in ($Subscriptions) and availability < 100\n| project ['date'] , subscriptionId, id, location, name, availability\n| order by availability asc \n| order by ['date'] asc",
+                    "querySource": "raw",
+                    "queryType": "KQL",
+                    "rawMode": true,
+                    "refId": "A",
+                    "resultFormat": "table"
+                }
+            ],
+            "title": "# of CosmosDB with Availability < 100",
+            "type": "table"
         }
-      ],
-      "title": "# of CosmosDB with Availability < 100",
-      "type": "table"
-    }
-  ],
-  "refresh": false,
-  "schemaVersion": 37,
-  "style": "dark",
-  "tags": [],
-  "templating": {
-    "list": [
-      {
-        "current": {
-          "selected": false,
-          "text": "2023-01-12 00:00:00",
-          "value": "2023-01-12 00:00:00"
-        },
-        "hide": 2,
-        "name": "selecteddate",
-        "options": [
-          {
-            "selected": true,
-            "text": "2023-01-12 00:00:00",
-            "value": "2023-01-12 00:00:00"
-          }
-        ],
-        "query": "2023-01-12 00:00:00",
-        "skipUrlSync": false,
-        "type": "textbox",
-        "datasource": null
-      },
-      {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
-        "datasource": {
-          "type": "grafana-azure-data-explorer-datasource",
-          "uid": "uRhkgPj4k"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": true,
-        "name": "Region",
-        "options": [],
-        "query": "",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
-        "datasource": {
-          "type": "grafana-azure-data-explorer-datasource",
-          "uid": "uRhkgPj4k"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": true,
-        "name": "Subscriptions",
-        "options": [],
-        "query": "",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
-        "datasource": {
-          "type": "grafana-azure-data-explorer-datasource",
-          "uid": "uRhkgPj4k"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": true,
-        "name": "Solution",
-        "options": [],
-        "query": "",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      }
-    ]
-  },
-  "time": {
-    "from": "now-6h",
-    "to": "now"
-  },
-  "timepicker": {},
-  "timezone": "utc",
-  "title": "CosmosDB",
-  "uid": "",
-  "version": 12,
-  "weekStart": ""
+    ],
+    "refresh": "",
+    "schemaVersion": 38,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+        "list": [
+            {
+                "current": {
+                    "selected": false,
+                    "text": "2023-01-12 00:00:00",
+                    "value": "2023-01-12 00:00:00"
+                },
+                "hide": 2,
+                "name": "selecteddate",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "2023-01-12 00:00:00",
+                        "value": "2023-01-12 00:00:00"
+                    }
+                ],
+                "query": "2023-01-12 00:00:00",
+                "skipUrlSync": false,
+                "type": "textbox"
+            },
+            {
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": {
+                    "type": "grafana-azure-data-explorer-datasource",
+                    "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                },
+                "definition": "",
+                "hide": 2,
+                "includeAll": false,
+                "multi": true,
+                "name": "Region",
+                "options": [],
+                "query": "",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
+            },
+            {
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": {
+                    "type": "grafana-azure-data-explorer-datasource",
+                    "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                },
+                "definition": "",
+                "hide": 2,
+                "includeAll": false,
+                "multi": true,
+                "name": "Subscriptions",
+                "options": [],
+                "query": "",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
+            },
+            {
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": {
+                    "type": "grafana-azure-data-explorer-datasource",
+                    "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                },
+                "definition": "",
+                "hide": 2,
+                "includeAll": false,
+                "multi": true,
+                "name": "Solution",
+                "options": [],
+                "query": "",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-6h",
+        "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "utc",
+    "title": "CosmosDB",
+    "uid": "a05004e1-8d3f-4e62-90e2-293853b8e41e",
+    "version": 2,
+    "weekStart": ""
 }

--- a/Utils/scripts/dashboard_templates/Eventhubs-1687851669082.json
+++ b/Utils/scripts/dashboard_templates/Eventhubs-1687851669082.json
@@ -1,238 +1,257 @@
 {
-  "annotations": {
-    "list": [
-      {
-        "builtIn": 1,
-        "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
-        },
-        "enable": true,
-        "hide": true,
-        "iconColor": "rgba(0, 211, 255, 1)",
-        "name": "Annotations & Alerts",
-        "target": {
-          "limit": 100,
-          "matchAny": false,
-          "tags": [],
-          "type": "dashboard"
-        },
-        "type": "dashboard"
-      }
-    ]
-  },
-  "editable": true,
-  "fiscalYearStartMonth": 0,
-  "graphTooltip": 0,
-  "id": 37,
-  "links": [],
-  "liveNow": false,
-  "panels": [
-    {
-      "datasource": {
-        "type": "grafana-azure-data-explorer-datasource",
-        "uid": "uRhkgPj4k"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "color-text"
-            },
-            "filterable": true,
-            "inspect": true
-          },
-          "decimals": 3,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-red",
-                "value": null
-              },
-              {
-                "color": "dark-green",
-                "value": 100
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 12,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 2,
-      "options": {
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": true
-      },
-      "pluginVersion": "9.4.12",
-      "targets": [
-        {
-          "database": "func04-metricsdb",
-          "datasource": {
-            "type": "grafana-azure-data-explorer-datasource",
-            "uid": "uRhkgPj4k"
-          },
-          "expression": {
-            "from": {
-              "property": {
-                "name": "Vm_Availability",
-                "type": "string"
-              },
-              "type": "property"
-            },
-            "groupBy": {
-              "expressions": [],
-              "type": "and"
-            },
-            "reduce": {
-              "expressions": [],
-              "type": "and"
-            },
-            "where": {
-              "expressions": [],
-              "type": "and"
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": {
+                    "type": "grafana",
+                    "uid": "-- Grafana --"
+                },
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "target": {
+                    "limit": 100,
+                    "matchAny": false,
+                    "tags": [],
+                    "type": "dashboard"
+                },
+                "type": "dashboard"
             }
-          },
-          "pluginVersion": "4.4.1",
-          "query": "Eventhubs_Availability\n| project ['date'], id, location, name, incomingRequests, serverErrors,\n subscriptionId, availability = (incomingRequests-serverErrors)*100/incomingRequests\n| where  ['date']  == datetime($selecteddate)\n and location in ($Region) and subscriptionId in ($Subscriptions)\n and availability < 100\n| project ['date'] , subscriptionId, id, location, name, availability\n| order by availability asc \n| order by ['date'] asc",
-          "querySource": "raw",
-          "queryType": "KQL",
-          "rawMode": true,
-          "refId": "A",
-          "resultFormat": "table"
+        ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 39,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+        {
+            "datasource": {
+                "type": "grafana-azure-data-explorer-datasource",
+                "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "align": "auto",
+                        "cellOptions": {
+                            "type": "color-text"
+                        },
+                        "filterable": true,
+                        "inspect": true
+                    },
+                    "decimals": 3,
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "dark-red",
+                                "value": null
+                            },
+                            {
+                                "color": "dark-green",
+                                "value": 100
+                            }
+                        ]
+                    }
+                },
+                "overrides": [
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "id"
+                        },
+                        "properties": [
+                            {
+                                "id": "links",
+                                "value": [
+                                    {
+                                        "targetBlank": true,
+                                        "title": "",
+                                        "url": "https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource${__value.raw}/overview"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            "gridPos": {
+                "h": 12,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 2,
+            "options": {
+                "cellHeight": "sm",
+                "footer": {
+                    "countRows": false,
+                    "fields": "",
+                    "reducer": [
+                        "sum"
+                    ],
+                    "show": false
+                },
+                "showHeader": true
+            },
+            "pluginVersion": "9.5.6",
+            "targets": [
+                {
+                    "database": "sk001-metricsdb",
+                    "datasource": {
+                        "type": "grafana-azure-data-explorer-datasource",
+                        "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                    },
+                    "expression": {
+                        "from": {
+                            "property": {
+                                "name": "Vm_Availability",
+                                "type": "string"
+                            },
+                            "type": "property"
+                        },
+                        "groupBy": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "reduce": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "where": {
+                            "expressions": [],
+                            "type": "and"
+                        }
+                    },
+                    "pluginVersion": "4.4.1",
+                    "query": "Eventhubs_Availability\n| project ['date'], id, location, name, incomingRequests, serverErrors,\n subscriptionId, availability = (incomingRequests-serverErrors)*100/incomingRequests\n| where  ['date']  == datetime($selecteddate)\n and location in ($Region) and subscriptionId in ($Subscriptions)\n and availability < 100\n| project ['date'] , subscriptionId, id, location, name, availability\n| order by availability asc \n| order by ['date'] asc",
+                    "querySource": "raw",
+                    "queryType": "KQL",
+                    "rawMode": true,
+                    "refId": "A",
+                    "resultFormat": "table"
+                }
+            ],
+            "title": "# of Eventhubs with Availability < 100",
+            "type": "table"
         }
-      ],
-      "title": "# of Eventhubs with Availability < 100",
-      "type": "table"
-    }
-  ],
-  "refresh": "",
-  "revision": 1,
-  "schemaVersion": 38,
-  "style": "dark",
-  "tags": [],
-  "templating": {
-    "list": [
-      {
-        "current": {
-          "selected": false,
-          "text": "2023-01-12 00:00:00",
-          "value": "2023-01-12 00:00:00"
-        },
-        "hide": 2,
-        "name": "selecteddate",
-        "options": [
-          {
-            "selected": true,
-            "text": "2023-01-12 00:00:00",
-            "value": "2023-01-12 00:00:00"
-          }
-        ],
-        "query": "2023-01-12 00:00:00",
-        "skipUrlSync": false,
-        "type": "textbox",
-        "datasource": null
-      },
-      {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
-        "datasource": {
-          "type": "grafana-azure-data-explorer-datasource",
-          "uid": "uRhkgPj4k"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": true,
-        "name": "Region",
-        "options": [],
-        "query": "",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
-        "datasource": {
-          "type": "grafana-azure-data-explorer-datasource",
-          "uid": "uRhkgPj4k"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": true,
-        "name": "Subscriptions",
-        "options": [],
-        "query": "",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
-        "datasource": {
-          "type": "grafana-azure-data-explorer-datasource",
-          "uid": "uRhkgPj4k"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": true,
-        "name": "Solution",
-        "options": [],
-        "query": "",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      }
-    ]
-  },
-  "time": {
-    "from": "now-6h",
-    "to": "now"
-  },
-  "timepicker": {},
-  "timezone": "utc",
-  "title": "Eventhubs",
-  "uid": "K9cdIeu4z",
-  "version": 4,
-  "weekStart": ""
+    ],
+    "refresh": "",
+    "revision": 1,
+    "schemaVersion": 38,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+        "list": [
+            {
+                "current": {
+                    "selected": false,
+                    "text": "2023-01-12 00:00:00",
+                    "value": "2023-01-12 00:00:00"
+                },
+                "hide": 2,
+                "name": "selecteddate",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "2023-01-12 00:00:00",
+                        "value": "2023-01-12 00:00:00"
+                    }
+                ],
+                "query": "2023-01-12 00:00:00",
+                "skipUrlSync": false,
+                "type": "textbox"
+            },
+            {
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": {
+                    "type": "grafana-azure-data-explorer-datasource",
+                    "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                },
+                "definition": "",
+                "hide": 2,
+                "includeAll": false,
+                "multi": true,
+                "name": "Region",
+                "options": [],
+                "query": "",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
+            },
+            {
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": {
+                    "type": "grafana-azure-data-explorer-datasource",
+                    "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                },
+                "definition": "",
+                "hide": 2,
+                "includeAll": false,
+                "multi": true,
+                "name": "Subscriptions",
+                "options": [],
+                "query": "",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
+            },
+            {
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": {
+                    "type": "grafana-azure-data-explorer-datasource",
+                    "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                },
+                "definition": "",
+                "hide": 2,
+                "includeAll": false,
+                "multi": true,
+                "name": "Solution",
+                "options": [],
+                "query": "",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-6h",
+        "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "utc",
+    "title": "Eventhubs",
+    "uid": "K9cdIeu4z",
+    "version": 2,
+    "weekStart": ""
 }

--- a/Utils/scripts/dashboard_templates/Firewalls-1689786810784.json
+++ b/Utils/scripts/dashboard_templates/Firewalls-1689786810784.json
@@ -1,263 +1,273 @@
 {
-  "annotations": {
-    "list": [
-      {
-        "builtIn": 1,
-        "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
-        },
-        "enable": true,
-        "hide": true,
-        "iconColor": "rgba(0, 211, 255, 1)",
-        "name": "Annotations & Alerts",
-        "target": {
-          "limit": 100,
-          "matchAny": false,
-          "tags": [],
-          "type": "dashboard"
-        },
-        "type": "dashboard"
-      }
-    ]
-  },
-  "editable": true,
-  "fiscalYearStartMonth": 0,
-  "graphTooltip": 0,
-  "id": 37,
-  "links": [],
-  "liveNow": false,
-  "panels": [
-    {
-      "datasource": {
-        "type": "grafana-azure-data-explorer-datasource",
-        "uid": "rviRxljVk"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "color-text"
-            },
-            "filterable": true,
-            "inspect": true
-          },
-          "decimals": 3,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-red",
-                "value": null
-              },
-              {
-                "color": "dark-green",
-                "value": 100
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "name"
-            },
-            "properties": [
-              {
-                "id": "custom.width"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "location"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 189
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 2,
-      "options": {
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": true,
-        "sortBy": []
-      },
-      "pluginVersion": "9.4.12",
-      "targets": [
-        {
-          "database": "main12-metricsdb",
-          "datasource": {
-            "type": "grafana-azure-data-explorer-datasource",
-            "uid": "rviRxljVk"
-          },
-          "expression": {
-            "from": {
-              "property": {
-                "name": "Vm_Availability",
-                "type": "string"
-              },
-              "type": "property"
-            },
-            "groupBy": {
-              "expressions": [],
-              "type": "and"
-            },
-            "reduce": {
-              "expressions": [],
-              "type": "and"
-            },
-            "where": {
-              "expressions": [],
-              "type": "and"
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": {
+                    "type": "grafana",
+                    "uid": "-- Grafana --"
+                },
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "target": {
+                    "limit": 100,
+                    "matchAny": false,
+                    "tags": [],
+                    "type": "dashboard"
+                },
+                "type": "dashboard"
             }
-          },
-          "pluginVersion": "4.5.0",
-          "query": "Firewall_Availability\n| where  ['date']  == datetime($selecteddate) and isnotnull(availability)\nand location in ($Region) and subscriptionId in ($Subscriptions) and availability < 100\n| project ['date'] , subscriptionId, id, location, name, availability\n| order by availability asc \n| order by ['date'] asc",
-          "querySource": "raw",
-          "queryType": "KQL",
-          "rawMode": true,
-          "refId": "A",
-          "resultFormat": "table"
+        ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 32,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+        {
+            "datasource": {
+                "type": "grafana-azure-data-explorer-datasource",
+                "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "align": "auto",
+                        "cellOptions": {
+                            "type": "color-text"
+                        },
+                        "filterable": true,
+                        "inspect": true
+                    },
+                    "decimals": 3,
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "dark-red",
+                                "value": null
+                            },
+                            {
+                                "color": "dark-green",
+                                "value": 100
+                            }
+                        ]
+                    }
+                },
+                "overrides": [
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "id"
+                        },
+                        "properties": [
+                            {
+                                "id": "custom.width"
+                            },
+                            {
+                                "id": "links",
+                                "value": [
+                                    {
+                                        "targetBlank": true,
+                                        "title": "",
+                                        "url": "https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource${__value.raw}/overview"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "location"
+                        },
+                        "properties": [
+                            {
+                                "id": "custom.width",
+                                "value": 189
+                            }
+                        ]
+                    }
+                ]
+            },
+            "gridPos": {
+                "h": 10,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 2,
+            "options": {
+                "cellHeight": "sm",
+                "footer": {
+                    "countRows": false,
+                    "fields": "",
+                    "reducer": [
+                        "sum"
+                    ],
+                    "show": false
+                },
+                "showHeader": true,
+                "sortBy": []
+            },
+            "pluginVersion": "9.5.6",
+            "targets": [
+                {
+                    "database": "sk001-metricsdb",
+                    "datasource": {
+                        "type": "grafana-azure-data-explorer-datasource",
+                        "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                    },
+                    "expression": {
+                        "from": {
+                            "property": {
+                                "name": "Vm_Availability",
+                                "type": "string"
+                            },
+                            "type": "property"
+                        },
+                        "groupBy": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "reduce": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "where": {
+                            "expressions": [],
+                            "type": "and"
+                        }
+                    },
+                    "pluginVersion": "4.5.0",
+                    "query": "Firewall_Availability\n| where  ['date']  == datetime($selecteddate) and isnotnull(availability)\nand location in ($Region) and subscriptionId in ($Subscriptions) and availability < 100\n| project ['date'] , subscriptionId, id, location, name, availability\n| order by availability asc \n| order by ['date'] asc",
+                    "querySource": "raw",
+                    "queryType": "KQL",
+                    "rawMode": true,
+                    "refId": "A",
+                    "resultFormat": "table"
+                }
+            ],
+            "title": "# of Firewall with Availability < 100",
+            "type": "table"
         }
-      ],
-      "title": "# of Firewall with Availability < 100",
-      "type": "table"
-    }
-  ],
-  "refresh": "",
-  "revision": 1,
-  "schemaVersion": 38,
-  "style": "dark",
-  "tags": [],
-  "templating": {
-    "list": [
-      {
-        "current": {
-          "selected": false,
-          "text": "2023-01-12 00:00:00",
-          "value": "2023-01-12 00:00:00"
-        },
-        "hide": 2,
-        "name": "selecteddate",
-        "options": [
-          {
-            "selected": true,
-            "text": "2023-01-12 00:00:00",
-            "value": "2023-01-12 00:00:00"
-          }
-        ],
-        "query": "2023-01-12 00:00:00",
-        "skipUrlSync": false,
-        "type": "textbox",
-        "datasource": null
-      },
-      {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
-        "datasource": {
-          "type": "grafana-azure-data-explorer-datasource",
-          "uid": "rviRxljVk"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": true,
-        "name": "Region",
-        "options": [],
-        "query": "",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
-        "datasource": {
-          "type": "grafana-azure-data-explorer-datasource",
-          "uid": "rviRxljVk"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": true,
-        "name": "Subscriptions",
-        "options": [],
-        "query": "",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
-        "datasource": {
-          "type": "grafana-azure-data-explorer-datasource",
-          "uid": "rviRxljVk"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": true,
-        "name": "Solution",
-        "options": [],
-        "query": "",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      }
-    ]
-  },
-  "time": {
-    "from": "now-6h",
-    "to": "now"
-  },
-  "timepicker": {},
-  "timezone": "utc",
-  "title": "Firewalls",
-  "uid": "8HDuNUC4z",
-  "version": 3,
-  "weekStart": ""
+    ],
+    "refresh": "",
+    "revision": 1,
+    "schemaVersion": 38,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+        "list": [
+            {
+                "current": {
+                    "selected": false,
+                    "text": "2023-01-12 00:00:00",
+                    "value": "2023-01-12 00:00:00"
+                },
+                "hide": 2,
+                "name": "selecteddate",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "2023-01-12 00:00:00",
+                        "value": "2023-01-12 00:00:00"
+                    }
+                ],
+                "query": "2023-01-12 00:00:00",
+                "skipUrlSync": false,
+                "type": "textbox"
+            },
+            {
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": {
+                    "type": "grafana-azure-data-explorer-datasource",
+                    "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                },
+                "definition": "",
+                "hide": 2,
+                "includeAll": false,
+                "multi": true,
+                "name": "Region",
+                "options": [],
+                "query": "",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
+            },
+            {
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": {
+                    "type": "grafana-azure-data-explorer-datasource",
+                    "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                },
+                "definition": "",
+                "hide": 2,
+                "includeAll": false,
+                "multi": true,
+                "name": "Subscriptions",
+                "options": [],
+                "query": "",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
+            },
+            {
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": {
+                    "type": "grafana-azure-data-explorer-datasource",
+                    "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                },
+                "definition": "",
+                "hide": 2,
+                "includeAll": false,
+                "multi": true,
+                "name": "Solution",
+                "options": [],
+                "query": "",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-6h",
+        "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "utc",
+    "title": "Firewalls",
+    "uid": "8HDuNUC4z",
+    "version": 2,
+    "weekStart": ""
 }

--- a/Utils/scripts/dashboard_templates/Keyvault-1679088939482.json
+++ b/Utils/scripts/dashboard_templates/Keyvault-1679088939482.json
@@ -1,233 +1,256 @@
 {
-  "annotations": {
-    "list": [
-      {
-        "builtIn": 1,
-        "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
-        },
-        "enable": true,
-        "hide": true,
-        "iconColor": "rgba(0, 211, 255, 1)",
-        "name": "Annotations & Alerts",
-        "target": {
-          "limit": 100,
-          "matchAny": false,
-          "tags": [],
-          "type": "dashboard"
-        },
-        "type": "dashboard"
-      }
-    ]
-  },
-  "editable": true,
-  "fiscalYearStartMonth": 0,
-  "graphTooltip": 0,
-  "id": 29,
-  "links": [],
-  "liveNow": false,
-  "panels": [
-    {
-      "datasource": {
-        "type": "grafana-azure-data-explorer-datasource",
-        "uid": "uRhkgPj4k"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "align": "auto",
-            "displayMode": "color-text",
-            "filterable": true,
-            "inspect": true
-          },
-          "decimals": 3,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-red",
-                "value": null
-              },
-              {
-                "color": "dark-green",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 13,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 2,
-      "options": {
-        "footer": {
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": true
-      },
-      "pluginVersion": "9.3.8",
-      "targets": [
-        {
-          "database": "func04-metricsdb",
-          "datasource": {
-            "type": "grafana-azure-data-explorer-datasource",
-            "uid": "uRhkgPj4k"
-          },
-          "expression": {
-            "from": {
-              "property": {
-                "name": "Vm_Availability",
-                "type": "string"
-              },
-              "type": "property"
-            },
-            "groupBy": {
-              "expressions": [],
-              "type": "and"
-            },
-            "reduce": {
-              "expressions": [],
-              "type": "and"
-            },
-            "where": {
-              "expressions": [],
-              "type": "and"
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": {
+                    "type": "grafana",
+                    "uid": "-- Grafana --"
+                },
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "target": {
+                    "limit": 100,
+                    "matchAny": false,
+                    "tags": [],
+                    "type": "dashboard"
+                },
+                "type": "dashboard"
             }
-          },
-          "pluginVersion": "4.2.0",
-          "query": "Keyvault_Availability\n| where  ['date']  == datetime($selecteddate) and isnotnull(availability)\nand location in ($Region) and subscriptionId in ($Subscriptions) and availability < 100\n| project ['date'] , subscriptionId, id, location, name, availability\n| order by availability asc \n| order by ['date'] asc",
-          "querySource": "raw",
-          "rawMode": true,
-          "refId": "A",
-          "resultFormat": "table"
+        ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 33,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+        {
+            "datasource": {
+                "type": "grafana-azure-data-explorer-datasource",
+                "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "align": "auto",
+                        "cellOptions": {
+                            "type": "color-text"
+                        },
+                        "filterable": true,
+                        "inspect": true
+                    },
+                    "decimals": 3,
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "dark-red",
+                                "value": null
+                            },
+                            {
+                                "color": "dark-green",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": [
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "id"
+                        },
+                        "properties": [
+                            {
+                                "id": "links",
+                                "value": [
+                                    {
+                                        "targetBlank": true,
+                                        "title": "",
+                                        "url": "https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource${__value.raw}/overview"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            "gridPos": {
+                "h": 13,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 2,
+            "options": {
+                "cellHeight": "sm",
+                "footer": {
+                    "countRows": false,
+                    "fields": "",
+                    "reducer": [
+                        "sum"
+                    ],
+                    "show": false
+                },
+                "showHeader": true
+            },
+            "pluginVersion": "9.5.6",
+            "targets": [
+                {
+                    "database": "sk001-metricsdb",
+                    "datasource": {
+                        "type": "grafana-azure-data-explorer-datasource",
+                        "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                    },
+                    "expression": {
+                        "from": {
+                            "property": {
+                                "name": "Vm_Availability",
+                                "type": "string"
+                            },
+                            "type": "property"
+                        },
+                        "groupBy": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "reduce": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "where": {
+                            "expressions": [],
+                            "type": "and"
+                        }
+                    },
+                    "pluginVersion": "4.5.0",
+                    "query": "Keyvault_Availability\n| where  ['date']  == datetime($selecteddate) and isnotnull(availability)\nand location in ($Region) and subscriptionId in ($Subscriptions) and availability < 100\n| project ['date'] , subscriptionId, id, location, name, availability\n| order by availability asc \n| order by ['date'] asc",
+                    "querySource": "raw",
+                    "queryType": "KQL",
+                    "rawMode": true,
+                    "refId": "A",
+                    "resultFormat": "table"
+                }
+            ],
+            "title": "# of Keyvaults with Availability < 100",
+            "type": "table"
         }
-      ],
-      "title": "# of Keyvaults with Availability < 100",
-      "type": "table"
-    }
-  ],
-  "refresh": false,
-  "schemaVersion": 37,
-  "style": "dark",
-  "tags": [],
-  "templating": {
-    "list": [
-      {
-        "current": {
-          "selected": false,
-          "text": "2023-01-12 00:00:00",
-          "value": "2023-01-12 00:00:00"
-        },
-        "hide": 2,
-        "name": "selecteddate",
-        "options": [
-          {
-            "selected": true,
-            "text": "2023-01-12 00:00:00",
-            "value": "2023-01-12 00:00:00"
-          }
-        ],
-        "query": "2023-01-12 00:00:00",
-        "skipUrlSync": false,
-        "type": "textbox",
-        "datasource": null
-      },
-      {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
-        "datasource": {
-          "type": "grafana-azure-data-explorer-datasource",
-          "uid": "uRhkgPj4k"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": true,
-        "name": "Region",
-        "options": [],
-        "query": "",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
-        "datasource": {
-          "type": "grafana-azure-data-explorer-datasource",
-          "uid": "uRhkgPj4k"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": true,
-        "name": "Subscriptions",
-        "options": [],
-        "query": "",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
-        "datasource": {
-          "type": "grafana-azure-data-explorer-datasource",
-          "uid": "uRhkgPj4k"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": true,
-        "name": "Solution",
-        "options": [],
-        "query": "",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      }
-    ]
-  },
-  "time": {
-    "from": "now-6h",
-    "to": "now"
-  },
-  "timepicker": {},
-  "timezone": "utc",
-  "title": "Keyvault",
-  "uid": "",
-  "version": 12,
-  "weekStart": ""
+    ],
+    "refresh": "",
+    "schemaVersion": 38,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+        "list": [
+            {
+                "current": {
+                    "selected": false,
+                    "text": "2023-01-12 00:00:00",
+                    "value": "2023-01-12 00:00:00"
+                },
+                "hide": 2,
+                "name": "selecteddate",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "2023-01-12 00:00:00",
+                        "value": "2023-01-12 00:00:00"
+                    }
+                ],
+                "query": "2023-01-12 00:00:00",
+                "skipUrlSync": false,
+                "type": "textbox"
+            },
+            {
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": {
+                    "type": "grafana-azure-data-explorer-datasource",
+                    "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                },
+                "definition": "",
+                "hide": 2,
+                "includeAll": false,
+                "multi": true,
+                "name": "Region",
+                "options": [],
+                "query": "",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
+            },
+            {
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": {
+                    "type": "grafana-azure-data-explorer-datasource",
+                    "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                },
+                "definition": "",
+                "hide": 2,
+                "includeAll": false,
+                "multi": true,
+                "name": "Subscriptions",
+                "options": [],
+                "query": "",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
+            },
+            {
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": {
+                    "type": "grafana-azure-data-explorer-datasource",
+                    "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                },
+                "definition": "",
+                "hide": 2,
+                "includeAll": false,
+                "multi": true,
+                "name": "Solution",
+                "options": [],
+                "query": "",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-6h",
+        "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "utc",
+    "title": "Keyvault",
+    "uid": "e3c65d8f-73f2-44db-a13e-2f37494d10a8",
+    "version": 2,
+    "weekStart": ""
 }

--- a/Utils/scripts/dashboard_templates/Loadbalancer-1679088952762.json
+++ b/Utils/scripts/dashboard_templates/Loadbalancer-1679088952762.json
@@ -1,233 +1,256 @@
 {
-  "annotations": {
-    "list": [
-      {
-        "builtIn": 1,
-        "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
-        },
-        "enable": true,
-        "hide": true,
-        "iconColor": "rgba(0, 211, 255, 1)",
-        "name": "Annotations & Alerts",
-        "target": {
-          "limit": 100,
-          "matchAny": false,
-          "tags": [],
-          "type": "dashboard"
-        },
-        "type": "dashboard"
-      }
-    ]
-  },
-  "editable": true,
-  "fiscalYearStartMonth": 0,
-  "graphTooltip": 0,
-  "id": 31,
-  "links": [],
-  "liveNow": false,
-  "panels": [
-    {
-      "datasource": {
-        "type": "grafana-azure-data-explorer-datasource",
-        "uid": "uRhkgPj4k"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "align": "auto",
-            "displayMode": "color-text",
-            "filterable": true,
-            "inspect": true
-          },
-          "decimals": 3,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-red",
-                "value": null
-              },
-              {
-                "color": "dark-green",
-                "value": 100
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 12,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 2,
-      "options": {
-        "footer": {
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": true
-      },
-      "pluginVersion": "9.3.8",
-      "targets": [
-        {
-          "database": "func04-metricsdb",
-          "datasource": {
-            "type": "grafana-azure-data-explorer-datasource",
-            "uid": "uRhkgPj4k"
-          },
-          "expression": {
-            "from": {
-              "property": {
-                "name": "Vm_Availability",
-                "type": "string"
-              },
-              "type": "property"
-            },
-            "groupBy": {
-              "expressions": [],
-              "type": "and"
-            },
-            "reduce": {
-              "expressions": [],
-              "type": "and"
-            },
-            "where": {
-              "expressions": [],
-              "type": "and"
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": {
+                    "type": "grafana",
+                    "uid": "-- Grafana --"
+                },
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "target": {
+                    "limit": 100,
+                    "matchAny": false,
+                    "tags": [],
+                    "type": "dashboard"
+                },
+                "type": "dashboard"
             }
-          },
-          "pluginVersion": "4.2.0",
-          "query": "Loadbalancer_Availability\n| where  ['date']  == datetime($selecteddate) and isnotnull(availability)\nand location in ($Region) and subscriptionId in ($Subscriptions) and availability < 100\n| project ['date'] , subscriptionId, id, location, name, availability\n| order by availability asc \n| order by ['date'] asc",
-          "querySource": "raw",
-          "rawMode": true,
-          "refId": "A",
-          "resultFormat": "table"
+        ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 30,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+        {
+            "datasource": {
+                "type": "grafana-azure-data-explorer-datasource",
+                "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "align": "auto",
+                        "cellOptions": {
+                            "type": "color-text"
+                        },
+                        "filterable": true,
+                        "inspect": true
+                    },
+                    "decimals": 3,
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "dark-red",
+                                "value": null
+                            },
+                            {
+                                "color": "dark-green",
+                                "value": 100
+                            }
+                        ]
+                    }
+                },
+                "overrides": [
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "id"
+                        },
+                        "properties": [
+                            {
+                                "id": "links",
+                                "value": [
+                                    {
+                                        "targetBlank": true,
+                                        "title": "",
+                                        "url": "https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource${__value.raw}/overview"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            "gridPos": {
+                "h": 12,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 2,
+            "options": {
+                "cellHeight": "sm",
+                "footer": {
+                    "countRows": false,
+                    "fields": "",
+                    "reducer": [
+                        "sum"
+                    ],
+                    "show": false
+                },
+                "showHeader": true
+            },
+            "pluginVersion": "9.5.6",
+            "targets": [
+                {
+                    "database": "sk001-metricsdb",
+                    "datasource": {
+                        "type": "grafana-azure-data-explorer-datasource",
+                        "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                    },
+                    "expression": {
+                        "from": {
+                            "property": {
+                                "name": "Vm_Availability",
+                                "type": "string"
+                            },
+                            "type": "property"
+                        },
+                        "groupBy": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "reduce": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "where": {
+                            "expressions": [],
+                            "type": "and"
+                        }
+                    },
+                    "pluginVersion": "4.5.0",
+                    "query": "Loadbalancer_Availability\n| where  ['date']  == datetime($selecteddate) and isnotnull(availability)\nand location in ($Region) and subscriptionId in ($Subscriptions) and availability < 100\n| project ['date'] , subscriptionId, id, location, name, availability\n| order by availability asc \n| order by ['date'] asc",
+                    "querySource": "raw",
+                    "queryType": "KQL",
+                    "rawMode": true,
+                    "refId": "A",
+                    "resultFormat": "table"
+                }
+            ],
+            "title": "# of Loadbalancers with Availability < 100",
+            "type": "table"
         }
-      ],
-      "title": "# of Loadbalancers with Availability < 100",
-      "type": "table"
-    }
-  ],
-  "refresh": false,
-  "schemaVersion": 37,
-  "style": "dark",
-  "tags": [],
-  "templating": {
-    "list": [
-      {
-        "current": {
-          "selected": false,
-          "text": "2023-01-12 00:00:00",
-          "value": "2023-01-12 00:00:00"
-        },
-        "hide": 2,
-        "name": "selecteddate",
-        "options": [
-          {
-            "selected": true,
-            "text": "2023-01-12 00:00:00",
-            "value": "2023-01-12 00:00:00"
-          }
-        ],
-        "query": "2023-01-12 00:00:00",
-        "skipUrlSync": false,
-        "type": "textbox",
-        "datasource": null
-      },
-      {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
-        "datasource": {
-          "type": "grafana-azure-data-explorer-datasource",
-          "uid": "uRhkgPj4k"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": true,
-        "name": "Region",
-        "options": [],
-        "query": "",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
-        "datasource": {
-          "type": "grafana-azure-data-explorer-datasource",
-          "uid": "uRhkgPj4k"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": true,
-        "name": "Subscriptions",
-        "options": [],
-        "query": "",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
-        "datasource": {
-          "type": "grafana-azure-data-explorer-datasource",
-          "uid": "uRhkgPj4k"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": true,
-        "name": "Solution",
-        "options": [],
-        "query": "",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      }
-    ]
-  },
-  "time": {
-    "from": "now-6h",
-    "to": "now"
-  },
-  "timepicker": {},
-  "timezone": "utc",
-  "title": "Loadbalancer",
-  "uid": "",
-  "version": 11,
-  "weekStart": ""
+    ],
+    "refresh": "",
+    "schemaVersion": 38,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+        "list": [
+            {
+                "current": {
+                    "selected": false,
+                    "text": "2023-01-12 00:00:00",
+                    "value": "2023-01-12 00:00:00"
+                },
+                "hide": 2,
+                "name": "selecteddate",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "2023-01-12 00:00:00",
+                        "value": "2023-01-12 00:00:00"
+                    }
+                ],
+                "query": "2023-01-12 00:00:00",
+                "skipUrlSync": false,
+                "type": "textbox"
+            },
+            {
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": {
+                    "type": "grafana-azure-data-explorer-datasource",
+                    "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                },
+                "definition": "",
+                "hide": 2,
+                "includeAll": false,
+                "multi": true,
+                "name": "Region",
+                "options": [],
+                "query": "",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
+            },
+            {
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": {
+                    "type": "grafana-azure-data-explorer-datasource",
+                    "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                },
+                "definition": "",
+                "hide": 2,
+                "includeAll": false,
+                "multi": true,
+                "name": "Subscriptions",
+                "options": [],
+                "query": "",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
+            },
+            {
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": {
+                    "type": "grafana-azure-data-explorer-datasource",
+                    "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                },
+                "definition": "",
+                "hide": 2,
+                "includeAll": false,
+                "multi": true,
+                "name": "Solution",
+                "options": [],
+                "query": "",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-6h",
+        "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "utc",
+    "title": "Loadbalancer",
+    "uid": "edbbddfb-a8d7-4b5d-bfa4-9703ac678f2b",
+    "version": 4,
+    "weekStart": ""
 }

--- a/Utils/scripts/dashboard_templates/LogAnalytics-1688018903992.json
+++ b/Utils/scripts/dashboard_templates/LogAnalytics-1688018903992.json
@@ -1,238 +1,257 @@
 {
-  "annotations": {
-    "list": [
-      {
-        "builtIn": 1,
-        "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
-        },
-        "enable": true,
-        "hide": true,
-        "iconColor": "rgba(0, 211, 255, 1)",
-        "name": "Annotations & Alerts",
-        "target": {
-          "limit": 100,
-          "matchAny": false,
-          "tags": [],
-          "type": "dashboard"
-        },
-        "type": "dashboard"
-      }
-    ]
-  },
-  "editable": true,
-  "fiscalYearStartMonth": 0,
-  "graphTooltip": 0,
-  "id": 38,
-  "links": [],
-  "liveNow": false,
-  "panels": [
-    {
-      "datasource": {
-        "type": "grafana-azure-data-explorer-datasource",
-        "uid": "uRhkgPj4k"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "color-text"
-            },
-            "filterable": true,
-            "inspect": true
-          },
-          "decimals": 3,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-red",
-                "value": null
-              },
-              {
-                "color": "dark-green",
-                "value": 100
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 12,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 2,
-      "options": {
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": true
-      },
-      "pluginVersion": "9.4.12",
-      "targets": [
-        {
-          "database": "func04-metricsdb",
-          "datasource": {
-            "type": "grafana-azure-data-explorer-datasource",
-            "uid": "uRhkgPj4k"
-          },
-          "expression": {
-            "from": {
-              "property": {
-                "name": "Vm_Availability",
-                "type": "string"
-              },
-              "type": "property"
-            },
-            "groupBy": {
-              "expressions": [],
-              "type": "and"
-            },
-            "reduce": {
-              "expressions": [],
-              "type": "and"
-            },
-            "where": {
-              "expressions": [],
-              "type": "and"
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": {
+                    "type": "grafana",
+                    "uid": "-- Grafana --"
+                },
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "target": {
+                    "limit": 100,
+                    "matchAny": false,
+                    "tags": [],
+                    "type": "dashboard"
+                },
+                "type": "dashboard"
             }
-          },
-          "pluginVersion": "4.4.1",
-          "query": "LogAnalytics_Availability\n| where  ['date']  == datetime($selecteddate) and isnotnull(availability)\nand location in ($Region) and subscriptionId in ($Subscriptions) and availability < 100\n| distinct ['date'] , subscriptionId, id, location, name, availability\n| order by availability asc \n| order by ['date'] asc",
-          "querySource": "raw",
-          "queryType": "KQL",
-          "rawMode": true,
-          "refId": "A",
-          "resultFormat": "table"
+        ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 35,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+        {
+            "datasource": {
+                "type": "grafana-azure-data-explorer-datasource",
+                "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+            },
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "align": "auto",
+                        "cellOptions": {
+                            "type": "color-text"
+                        },
+                        "filterable": true,
+                        "inspect": true
+                    },
+                    "decimals": 3,
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "dark-red",
+                                "value": null
+                            },
+                            {
+                                "color": "dark-green",
+                                "value": 100
+                            }
+                        ]
+                    }
+                },
+                "overrides": [
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "id"
+                        },
+                        "properties": [
+                            {
+                                "id": "links",
+                                "value": [
+                                    {
+                                        "targetBlank": true,
+                                        "title": "",
+                                        "url": "https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource${__value.raw}/overview"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            "gridPos": {
+                "h": 12,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 2,
+            "options": {
+                "cellHeight": "sm",
+                "footer": {
+                    "countRows": false,
+                    "fields": "",
+                    "reducer": [
+                        "sum"
+                    ],
+                    "show": false
+                },
+                "showHeader": true
+            },
+            "pluginVersion": "9.5.6",
+            "targets": [
+                {
+                    "database": "sk001-metricsdb",
+                    "datasource": {
+                        "type": "grafana-azure-data-explorer-datasource",
+                        "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                    },
+                    "expression": {
+                        "from": {
+                            "property": {
+                                "name": "Vm_Availability",
+                                "type": "string"
+                            },
+                            "type": "property"
+                        },
+                        "groupBy": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "reduce": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "where": {
+                            "expressions": [],
+                            "type": "and"
+                        }
+                    },
+                    "pluginVersion": "4.4.1",
+                    "query": "LogAnalytics_Availability\n| where  ['date']  == datetime($selecteddate) and isnotnull(availability)\nand location in ($Region) and subscriptionId in ($Subscriptions) and availability < 100\n| distinct ['date'] , subscriptionId, id, location, name, availability\n| order by availability asc \n| order by ['date'] asc",
+                    "querySource": "raw",
+                    "queryType": "KQL",
+                    "rawMode": true,
+                    "refId": "A",
+                    "resultFormat": "table"
+                }
+            ],
+            "title": "# of LogAnalytics with Availability < 100",
+            "type": "table"
         }
-      ],
-      "title": "# of LogAnalytics with Availability < 100",
-      "type": "table"
-    }
-  ],
-  "refresh": "",
-  "revision": 1,
-  "schemaVersion": 38,
-  "style": "dark",
-  "tags": [],
-  "templating": {
-    "list": [
-      {
-        "current": {
-          "selected": false,
-          "text": "2023-01-12 00:00:00",
-          "value": "2023-01-12 00:00:00"
-        },
-        "hide": 2,
-        "name": "selecteddate",
-        "options": [
-          {
-            "selected": true,
-            "text": "2023-01-12 00:00:00",
-            "value": "2023-01-12 00:00:00"
-          }
-        ],
-        "query": "2023-01-12 00:00:00",
-        "skipUrlSync": false,
-        "type": "textbox",
-        "datasource": null
-      },
-      {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
-        "datasource": {
-          "type": "grafana-azure-data-explorer-datasource",
-          "uid": "uRhkgPj4k"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": true,
-        "name": "Region",
-        "options": [],
-        "query": "",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
-        "datasource": {
-          "type": "grafana-azure-data-explorer-datasource",
-          "uid": "uRhkgPj4k"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": true,
-        "name": "Subscriptions",
-        "options": [],
-        "query": "",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
-        "datasource": {
-          "type": "grafana-azure-data-explorer-datasource",
-          "uid": "uRhkgPj4k"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": true,
-        "name": "Solution",
-        "options": [],
-        "query": "",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      }
-    ]
-  },
-  "time": {
-    "from": "now-6h",
-    "to": "now"
-  },
-  "timepicker": {},
-  "timezone": "utc",
-  "title": "LogAnalytics",
-  "uid": "mpNZfMr4k",
-  "version": 2,
-  "weekStart": ""
+    ],
+    "refresh": "",
+    "revision": 1,
+    "schemaVersion": 38,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+        "list": [
+            {
+                "current": {
+                    "selected": false,
+                    "text": "2023-01-12 00:00:00",
+                    "value": "2023-01-12 00:00:00"
+                },
+                "hide": 2,
+                "name": "selecteddate",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "2023-01-12 00:00:00",
+                        "value": "2023-01-12 00:00:00"
+                    }
+                ],
+                "query": "2023-01-12 00:00:00",
+                "skipUrlSync": false,
+                "type": "textbox"
+            },
+            {
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": {
+                    "type": "grafana-azure-data-explorer-datasource",
+                    "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                },
+                "definition": "",
+                "hide": 2,
+                "includeAll": false,
+                "multi": true,
+                "name": "Region",
+                "options": [],
+                "query": "",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
+            },
+            {
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": {
+                    "type": "grafana-azure-data-explorer-datasource",
+                    "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                },
+                "definition": "",
+                "hide": 2,
+                "includeAll": false,
+                "multi": true,
+                "name": "Subscriptions",
+                "options": [],
+                "query": "",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
+            },
+            {
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": {
+                    "type": "grafana-azure-data-explorer-datasource",
+                    "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                },
+                "definition": "",
+                "hide": 2,
+                "includeAll": false,
+                "multi": true,
+                "name": "Solution",
+                "options": [],
+                "query": "",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-6h",
+        "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "utc",
+    "title": "LogAnalytics",
+    "uid": "mpNZfMr4k",
+    "version": 2,
+    "weekStart": ""
 }

--- a/Utils/scripts/dashboard_templates/Storage-1679088963314.json
+++ b/Utils/scripts/dashboard_templates/Storage-1679088963314.json
@@ -1,258 +1,273 @@
 {
-  "annotations": {
-    "list": [
-      {
-        "builtIn": 1,
-        "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
-        },
-        "enable": true,
-        "hide": true,
-        "iconColor": "rgba(0, 211, 255, 1)",
-        "name": "Annotations & Alerts",
-        "target": {
-          "limit": 100,
-          "matchAny": false,
-          "tags": [],
-          "type": "dashboard"
-        },
-        "type": "dashboard"
-      }
-    ]
-  },
-  "editable": true,
-  "fiscalYearStartMonth": 0,
-  "graphTooltip": 0,
-  "id": 30,
-  "links": [],
-  "liveNow": false,
-  "panels": [
-    {
-      "datasource": {
-        "type": "grafana-azure-data-explorer-datasource",
-        "uid": "uRhkgPj4k"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "align": "auto",
-            "displayMode": "color-text",
-            "filterable": true,
-            "inspect": true
-          },
-          "decimals": 3,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-red",
-                "value": null
-              },
-              {
-                "color": "dark-green",
-                "value": 100
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "name"
-            },
-            "properties": [
-              {
-                "id": "custom.width"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "location"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 189
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 2,
-      "options": {
-        "footer": {
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": true,
-        "sortBy": []
-      },
-      "pluginVersion": "9.3.8",
-      "targets": [
-        {
-          "database": "func04-metricsdb",
-          "datasource": {
-            "type": "grafana-azure-data-explorer-datasource",
-            "uid": "uRhkgPj4k"
-          },
-          "expression": {
-            "from": {
-              "property": {
-                "name": "Vm_Availability",
-                "type": "string"
-              },
-              "type": "property"
-            },
-            "groupBy": {
-              "expressions": [],
-              "type": "and"
-            },
-            "reduce": {
-              "expressions": [],
-              "type": "and"
-            },
-            "where": {
-              "expressions": [],
-              "type": "and"
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": {
+                    "type": "grafana",
+                    "uid": "-- Grafana --"
+                },
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "target": {
+                    "limit": 100,
+                    "matchAny": false,
+                    "tags": [],
+                    "type": "dashboard"
+                },
+                "type": "dashboard"
             }
-          },
-          "pluginVersion": "4.2.0",
-          "query": "Storage_Availability\n| where  ['date']  == datetime($selecteddate) and isnotnull(availability)\nand location in ($Region) and subscriptionId in ($Subscriptions) and availability < 100\n| project ['date'] , subscriptionId, id, location, name, availability\n| order by availability asc \n| order by ['date'] asc",
-          "querySource": "raw",
-          "rawMode": true,
-          "refId": "A",
-          "resultFormat": "table"
+        ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 37,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+        {
+            "datasource": {
+                "type": "grafana-azure-data-explorer-datasource",
+                "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+            },
+            "description": "",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "align": "auto",
+                        "cellOptions": {
+                            "type": "color-text"
+                        },
+                        "filterable": true,
+                        "inspect": true
+                    },
+                    "decimals": 3,
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "dark-red",
+                                "value": null
+                            },
+                            {
+                                "color": "dark-green",
+                                "value": 100
+                            }
+                        ]
+                    }
+                },
+                "overrides": [
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "id"
+                        },
+                        "properties": [
+                            {
+                                "id": "custom.width"
+                            },
+                            {
+                                "id": "links",
+                                "value": [
+                                    {
+                                        "targetBlank": true,
+                                        "title": "",
+                                        "url": "https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource${__value.raw}/overview"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                            "id": "byName",
+                            "options": "location"
+                        },
+                        "properties": [
+                            {
+                                "id": "custom.width",
+                                "value": 189
+                            }
+                        ]
+                    }
+                ]
+            },
+            "gridPos": {
+                "h": 10,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 2,
+            "options": {
+                "cellHeight": "sm",
+                "footer": {
+                    "countRows": false,
+                    "fields": "",
+                    "reducer": [
+                        "sum"
+                    ],
+                    "show": false
+                },
+                "showHeader": true,
+                "sortBy": []
+            },
+            "pluginVersion": "9.5.6",
+            "targets": [
+                {
+                    "database": "sk001-metricsdb",
+                    "datasource": {
+                        "type": "grafana-azure-data-explorer-datasource",
+                        "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                    },
+                    "expression": {
+                        "from": {
+                            "property": {
+                                "name": "Vm_Availability",
+                                "type": "string"
+                            },
+                            "type": "property"
+                        },
+                        "groupBy": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "reduce": {
+                            "expressions": [],
+                            "type": "and"
+                        },
+                        "where": {
+                            "expressions": [],
+                            "type": "and"
+                        }
+                    },
+                    "pluginVersion": "4.5.0",
+                    "query": "Storage_Availability\n| where  ['date']  == datetime($selecteddate) and isnotnull(availability)\nand location in ($Region) and subscriptionId in ($Subscriptions) and availability < 100\n| project ['date'] , subscriptionId, id, location, name, availability\n| order by availability asc \n| order by ['date'] asc",
+                    "querySource": "raw",
+                    "queryType": "KQL",
+                    "rawMode": true,
+                    "refId": "A",
+                    "resultFormat": "table"
+                }
+            ],
+            "title": "# of Storage with Availability < 100",
+            "type": "table"
         }
-      ],
-      "title": "# of Storage with Availability < 100",
-      "type": "table"
-    }
-  ],
-  "refresh": false,
-  "schemaVersion": 37,
-  "style": "dark",
-  "tags": [],
-  "templating": {
-    "list": [
-      {
-        "current": {
-          "selected": false,
-          "text": "2023-01-12 00:00:00",
-          "value": "2023-01-12 00:00:00"
-        },
-        "hide": 2,
-        "name": "selecteddate",
-        "options": [
-          {
-            "selected": true,
-            "text": "2023-01-12 00:00:00",
-            "value": "2023-01-12 00:00:00"
-          }
-        ],
-        "query": "2023-01-12 00:00:00",
-        "skipUrlSync": false,
-        "type": "textbox",
-        "datasource": null
-      },
-      {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
-        "datasource": {
-          "type": "grafana-azure-data-explorer-datasource",
-          "uid": "uRhkgPj4k"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": true,
-        "name": "Region",
-        "options": [],
-        "query": "",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
-        "datasource": {
-          "type": "grafana-azure-data-explorer-datasource",
-          "uid": "uRhkgPj4k"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": true,
-        "name": "Subscriptions",
-        "options": [],
-        "query": "",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      },
-      {
-        "current": {
-          "isNone": true,
-          "selected": false,
-          "text": "None",
-          "value": ""
-        },
-        "datasource": {
-          "type": "grafana-azure-data-explorer-datasource",
-          "uid": "uRhkgPj4k"
-        },
-        "definition": "",
-        "hide": 2,
-        "includeAll": false,
-        "multi": true,
-        "name": "Solution",
-        "options": [],
-        "query": "",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
-      }
-    ]
-  },
-  "time": {
-    "from": "now-6h",
-    "to": "now"
-  },
-  "timepicker": {},
-  "timezone": "utc",
-  "title": "Storage",
-  "uid": "",
-  "version": 17,
-  "weekStart": ""
+    ],
+    "refresh": "",
+    "schemaVersion": 38,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+        "list": [
+            {
+                "current": {
+                    "selected": false,
+                    "text": "2023-01-12 00:00:00",
+                    "value": "2023-01-12 00:00:00"
+                },
+                "hide": 2,
+                "name": "selecteddate",
+                "options": [
+                    {
+                        "selected": true,
+                        "text": "2023-01-12 00:00:00",
+                        "value": "2023-01-12 00:00:00"
+                    }
+                ],
+                "query": "2023-01-12 00:00:00",
+                "skipUrlSync": false,
+                "type": "textbox"
+            },
+            {
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": {
+                    "type": "grafana-azure-data-explorer-datasource",
+                    "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                },
+                "definition": "",
+                "hide": 2,
+                "includeAll": false,
+                "multi": true,
+                "name": "Region",
+                "options": [],
+                "query": "",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
+            },
+            {
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": {
+                    "type": "grafana-azure-data-explorer-datasource",
+                    "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                },
+                "definition": "",
+                "hide": 2,
+                "includeAll": false,
+                "multi": true,
+                "name": "Subscriptions",
+                "options": [],
+                "query": "",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
+            },
+            {
+                "current": {
+                    "isNone": true,
+                    "selected": false,
+                    "text": "None",
+                    "value": ""
+                },
+                "datasource": {
+                    "type": "grafana-azure-data-explorer-datasource",
+                    "uid": "b14764b1-a62a-4955-a119-af3504be6a18"
+                },
+                "definition": "",
+                "hide": 2,
+                "includeAll": false,
+                "multi": true,
+                "name": "Solution",
+                "options": [],
+                "query": "",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "type": "query"
+            }
+        ]
+    },
+    "time": {
+        "from": "now-6h",
+        "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "utc",
+    "title": "Storage",
+    "uid": "e90a362b-0e3e-4da7-a725-0f35415d18bc",
+    "version": 4,
+    "weekStart": ""
 }

--- a/Utils/scripts/table_scripts.kql
+++ b/Utils/scripts/table_scripts.kql
@@ -43,7 +43,7 @@
 //create adx tables
 .create-merge table Resource_Providers (name: string, ['type']: string, resultTableName: string)
 
-.create-merge table Subscription_Names (subscriptionId: guid, name: string)
+.create-merge table Subscription_Names (subscriptionId: guid, name: string, tenantDomain: string)
 
 .create-merge table Subscriptions (solution: string, tenancy: string, component: string, subscriptionId: guid, createdAt: datetime)
 


### PR DESCRIPTION
## Purpose
Adding a hyperlink to resource id field in all drill downs in Grafana which leads to the resource's overview in Azure Portal. Currently, the hyperlink only supports single tenancy.  The resource id is converted to hyperlink for both past and incoming data. 


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What to Check
Verify that the following are valid
* Hyperlink (red arrow) is accurate for all resource types and subscriptions 
* Hyperlink leads to overview page for the resource in Azure Portal 
* Hyperlink is only applied to resource id field and doesn't alter other aspects of the dashboard's UI

![image](https://github.com/Azure-Samples/observabilitymetrics-demo/assets/143448207/1c636ca0-3413-4c41-a6cf-eb42d2513350)


<img width="758" alt="image" src="https://github.com/Azure-Samples/observabilitymetrics-demo/assets/143448207/4175c77c-4db3-4f3a-b569-a1e9c373ba7e">

## Other Information
You will need to remove the _availability < 100_ condition in the Subscriptions query if there is no data upon initial drill down.

<img width="687" alt="image" src="https://github.com/Azure-Samples/observabilitymetrics-demo/assets/143448207/2633d49c-4bbc-4d2d-8717-8eff1b9509e0">
