### PR TITLE
Fixing DB and table retention policies 

### DIFF
--- a/Utils/scripts/Terraform/resources/main.tf
+++ b/Utils/scripts/Terraform/resources/main.tf
@@ -239,7 +239,7 @@ resource "azurerm_kusto_database" "database" {
   depends_on = [azurerm_kusto_cluster.this]
 
   hot_cache_period   = "P7D"
-  soft_delete_period = "P183D"
+  soft_delete_period = "P365D"
 }
 
 

--- a/Utils/scripts/Terraform/resources/main.tf
+++ b/Utils/scripts/Terraform/resources/main.tf
@@ -239,7 +239,7 @@ resource "azurerm_kusto_database" "database" {
   depends_on = [azurerm_kusto_cluster.this]
 
   hot_cache_period   = "P7D"
-  soft_delete_period = "P31D"
+  soft_delete_period = "P183D"
 }
 
 

--- a/Utils/scripts/table_scripts.kql
+++ b/Utils/scripts/table_scripts.kql
@@ -382,3 +382,10 @@ let totalPush = Container_Registry_Availability_Raw
 .alter-merge table Container_Registry_Availability_Raw policy retention softdelete = 0s
 
 .alter-merge table LogAnalytics_Availability_Raw policy retention softdelete = 0s
+
+//Adding default (100 years) retention policy to Subscriptions and Resource Providers tables
+.alter table Subscriptions policy retention "{}"
+
+.alter table Resource_Providers policy retention "{}"
+
+.alter table Subscription_Names policy retention "{}"

--- a/Utils/scripts/table_scripts.kql
+++ b/Utils/scripts/table_scripts.kql
@@ -384,8 +384,8 @@ let totalPush = Container_Registry_Availability_Raw
 .alter-merge table LogAnalytics_Availability_Raw policy retention softdelete = 0s
 
 //Adding default (100 years) retention policy to Subscriptions and Resource Providers tables
-.alter-merge table Subscriptions policy retention "{}"
+.alter table Subscriptions policy retention "{}"
 
-.alter-merge table Resource_Providers policy retention "{}"
+.alter table Resource_Providers policy retention "{}"
 
-.alter-merge table Subscription_Names policy retention "{}"
+.alter table Subscription_Names policy retention "{}"

--- a/Utils/scripts/table_scripts.kql
+++ b/Utils/scripts/table_scripts.kql
@@ -384,8 +384,8 @@ let totalPush = Container_Registry_Availability_Raw
 .alter-merge table LogAnalytics_Availability_Raw policy retention softdelete = 0s
 
 //Adding default (100 years) retention policy to Subscriptions and Resource Providers tables
-.alter table Subscriptions policy retention "{}"
+.alter-merge table Subscriptions policy retention "{}"
 
-.alter table Resource_Providers policy retention "{}"
+.alter-merge table Resource_Providers policy retention "{}"
 
-.alter table Subscription_Names policy retention "{}"
+.alter-merge table Subscription_Names policy retention "{}"


### PR DESCRIPTION
## Purpose
Demo environment broke on 12/8/23 due to DB retention policy being set to 30 days (and inherited by all tables).  This caused the Subscriptions and Resource Providers table to be wiped and break the solution. 

The database policy is now set to 1 year. The Subscriptions, Subscription Names, and Resource Providers table retention policies are now set to the default of 100 years.


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What to Check
Verify that the following are valid
<img width="620" alt="image" src="https://github.com/Azure-Samples/observabilitymetrics-demo/assets/143448207/f03fbb2e-bd80-410b-9a3b-dce828d48679">

- Database policy is set to 1 year in ADX
<img width="617" alt="image" src="https://github.com/Azure-Samples/observabilitymetrics-demo/assets/143448207/6c3e27da-f9e8-4803-9eab-d2fc1dccf25b">


- Subscriptions, Subscription Names, and Resource Providers table retention policies are set to 100  years
<img width="616" alt="image" src="https://github.com/Azure-Samples/observabilitymetrics-demo/assets/143448207/4e7a7c3f-0e09-42d2-81d9-47823f50c7c1">
<img width="635" alt="image" src="https://github.com/Azure-Samples/observabilitymetrics-demo/assets/143448207/2ddc8566-d3a1-474f-a916-c1359fe74a15">
<img width="621" alt="image" src="https://github.com/Azure-Samples/observabilitymetrics-demo/assets/143448207/f859e653-f28b-446d-86a6-3787c8fc7ec2">

