### PR TITLE
Removing duplicate entries in ADX

### DIFF
--- a/AdxIngestFunctionApp/AdxIngestFunction.cs
+++ b/AdxIngestFunctionApp/AdxIngestFunction.cs
@@ -86,6 +86,11 @@ namespace Observability.AdxIngestFunctionApp
             }
             log.LogInformation($"Batch url: {batchUrl}");
 
+            string currTime = timeSpan.Split('/')[0];
+            string currResource = message.Type.Substring(message.Type.IndexOf('/') + 1);
+            string filePrefix = $"{message.Location}_{message.SubscriptionID}_{currTime}_{currResource}";
+            log.LogInformation($"Storage Blob File Prefix: {filePrefix}");
+
             using HttpRequestMessage httpRequest = new HttpRequestMessage(HttpMethod.Post, batchUrl);
 
             string msftTenantId = config.GetValue<string>("msftTenantId");
@@ -141,7 +146,7 @@ namespace Observability.AdxIngestFunctionApp
             var responseContent = await response.Content.ReadAsStringAsync(); //TODO: Should handle as stream and not bring into memory as a string. // see later converting string back to a stream in IngestToAdx2Async, AppendToBlobAsync
 
             var adx = new AdxClientHelper(config, log); 
-            await adx.IngestToAdx2Async(responseContent, message.ResultTable);
+            await adx.IngestToAdx2Async(responseContent, message.ResultTable, filePrefix);
         }
     }
 }


### PR DESCRIPTION
## Purpose
Adding a naming convention to storage blob files and checking if that prefix has already been seen before adding to storage container. This filters out the large amount of duplicate entries we have been seeing in ADX and Grafana. 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

You can use the following query in ADX (modify for different resources / availability columns) to get a sum of all duplicate entries

```
Storage_Availability
| summarize count() by ['date'], id, availability, subscriptionId, location, name
| where count_ > 1
| summarize sum(count_)
```

You may also use this query to see the entries (if any) that are duplicated and the duplicate count for each 

```
Storage_Availability
| summarize count() by ['date'], id, availability, subscriptionId, location, name
| where count_ > 1
| where ['date'] > ago(1d)
```
![image](https://github.com/Azure-Samples/observabilitymetrics-demo/assets/143448207/ba7f2589-37c7-49af-950d-4da0531500e2)
*Image taken from a deployment without these changes


## What to Check
Ensure that there are no duplicates in each resource availability table
![image](https://github.com/Azure-Samples/observabilitymetrics-demo/assets/143448207/bc608de6-88dd-4602-b816-299c9b8806c3)


## Other Information
<!-- Add any other helpful information that may be needed here. -->